### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fetchdts",
   "type": "module",
   "version": "0.1.7",
-  "packageManager": "pnpm@10.21.0",
+  "packageManager": "pnpm@11.1.2",
   "description": "A suite of type utilities for building strongly-typed APIs",
   "author": {
     "name": "Daniel Roe",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,8 @@ packages:
   - playground
 overrides:
   fetchdts: 'link:.'
-ignoredBuiltDependencies:
-  - esbuild
-  - unrs-resolver
-onlyBuiltDependencies:
-  - simple-git-hooks
+
+allowBuilds:
+  esbuild: false
+  simple-git-hooks: true
+  unrs-resolver: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`