### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "9.2.0",
-    "@types/node": "latest",
+    "@types/node": "^26.1.2",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.0",
     "installed-check": "10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: 9.2.0
         version: 9.2.0(@typescript-eslint/typescript-estree@8.65.0(supports-color@7.2.0)(typescript@6.0.3))(@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)(vitest@4.1.10)
       '@types/node':
-        specifier: latest
+        specifier: ^26.1.2
         version: 26.1.2
       '@vitest/coverage-v8':
         specifier: 4.1.10


### PR DESCRIPTION
`latest` is a curse and can easily drift, or change wildly on lockfile regeneration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js type definitions development dependency to a fixed compatible version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->