### PR TITLE
feat!: resolve routes at any depth + take pre-split segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,15 +300,13 @@ const routes = endpoints.flatMap(({ pattern, method, responseType }) =>
           // escapes are preserved, so a literal `*` arrives as `\*`
           : segment.replace(/\\(.)/g, '$1'),
     ),
-    metadata: { [method]: { responseType } },
+    // a handler with no method is valid for every verb
+    metadata: { [method ?? 'ALL']: { responseType } },
   })),
 )
 
 const schema = serializeRoutes('APISchema', routes)
 ```
-
-For an endpoint that is valid for every method, see
-[Handlers Registered for Every Method](#handlers-registered-for-every-method).
 
 For filesystem routes, [`unrouting`](https://github.com/unjs/unrouting) parses the major conventions
 and converts between them, reporting each lossy step rather than silently widening a pattern.
@@ -401,6 +399,22 @@ interface APISchema {
     }
   }
 }
+```
+
+`serializeRoutes` emits that form for an `ALL` entry, which is worth using over spelling out every
+method, as the generated file is several times smaller:
+
+```ts
+serializeRoutes('APISchema', [
+  {
+    segments: ['/api', '/hello'],
+    metadata: {
+      ALL: { responseType: '{ hello: string }' },
+      // a specific method takes precedence over `ALL`
+      POST: { bodyType: '{ name: string }', responseType: 'Created' }
+    }
+  }
+])
 ```
 
 ### Cross-Domain API Support

--- a/README.md
+++ b/README.md
@@ -417,6 +417,45 @@ serializeRoutes('APISchema', [
 ])
 ```
 
+### Requests Built From Runtime Values
+
+`` $fetch(`/api/posts/${id}`) `` has the type `` `/api/posts/${string}` ``, so it matches the dynamic
+parameter, but at runtime `id` could be `'static'` and hit a static sibling instead. By default the
+dynamic parameter's response is used, which is exact for a literal path and optimistic for this one.
+
+Where that matters, an endpoint can declare the response to use when the segment reaching it was not
+a literal:
+
+```ts
+interface APISchema {
+  '/api/posts': {
+    '/static': { [Endpoint]: { GET: { response: Static } } }
+    [DynamicParam]: {
+      [Endpoint]: {
+        GET: {
+          response: Post
+          ambiguousResponse: Post | Static
+        }
+      }
+    }
+  }
+}
+
+type A = TypedFetchResponseBody<APISchema, `/api/posts/${string}`> // Post | Static
+type B = TypedFetchResponseBody<APISchema, '/api/posts/123'> // Post
+type C = TypedFetchResponseBody<APISchema, '/api/posts/static'> // Static
+```
+
+The union is not computed for you, deliberately: which siblings a request could reach is a property
+of the route set, and whoever generates the schema knows it, so computing it once at generation time
+costs a fraction of deriving it at every call site. `serializeRoutes` emits an
+`ambiguousResponseType` like any other metadata field. An endpoint that declares no
+`ambiguousResponse` behaves exactly as before, so this is opt-in per endpoint.
+
+The alternative is only used where a *parameter* consumed a non-literal segment. A wildcard is
+unaffected, since it matches the rest of the path either way, and it applies to endpoints below the
+parameter too, so `` `/api/users/${string}/posts` `` can account for a `/api/users/me/posts` sibling.
+
 ### Cross-Domain API Support
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -417,6 +417,33 @@ serializeRoutes('APISchema', [
 ])
 ```
 
+### Registering a Route Without a Return Type
+
+A route whose response type isn't known, because a handler couldn't be resolved or is a proxy, is
+still a route, and should stay callable rather than looking like a typo. Register it for every method
+with nothing else declared:
+
+```ts
+serializeRoutes('APISchema', [
+  { segments: ['/api', '/proxy'], metadata: { ALL: {} } },
+])
+
+// [Endpoint]: Record<HTTPMethod, {}>
+```
+
+The path is then a valid input, takes any method, and its response is `unknown`. A path that matches
+nothing, or a method an endpoint doesn't register, is still `never`, so the two cases stay
+distinguishable:
+
+```ts
+type A = TypedFetchResponseBody<APISchema, '/api/proxy'> // unknown
+type B = TypedFetchResponseBody<APISchema, '/api/typo'> // never
+```
+
+Omitting `metadata` entirely is not the same thing: it emits no endpoint at all, so the path is not
+offered. That is deliberate, so that a generator which skips handlers it cannot type doesn't widen
+its surface by accident.
+
 ### Requests Built From Runtime Values
 
 `` $fetch(`/api/posts/${id}`) `` has the type `` `/api/posts/${string}` ``, so it matches the dynamic

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ interface APISchema {
         response: { id: number, name: string, email: string }
       }
     }
-    [DynamicParam]: { // /users/:id
+    [DynamicParam]: { // matches /users/123
       [Endpoint]: {
         GET: {
           response: { id: number, name: string, email: string }
@@ -149,14 +149,14 @@ interface Schema {
     POST: { body: Input, response: Data }
   }
 
-  // DynamicParam: Matches single path segments (e.g., /users/:id)
+  // DynamicParam: Matches a single path segment (e.g. the `123` of /users/123)
   [DynamicParam]: {
     [Endpoint]: {
       GET: { response: User }
     }
   }
 
-  // WildcardParam: Matches multiple path segments (e.g., /files/*)
+  // WildcardParam: Matches the rest of the path (e.g. the `a/b.txt` of /files/a/b.txt)
   [WildcardParam]: {
     [Endpoint]: {
       GET: { response: File }
@@ -229,14 +229,15 @@ const customHeader = response.headers.get('x-custom') // Typed based on schema
 ### Utilities
 
 #### `serializeRoutes(name, routes, options?)`
-Generate TypeScript schema from route definitions:
+
+Generate a TypeScript schema from route definitions. Each route is a list of segments, already split:
 
 ```ts
-import { serializeRoutes } from 'fetchdts'
+import { DynamicParam, serializeRoutes } from 'fetchdts'
 
 const schema = serializeRoutes('APISchema', [
   {
-    path: '/users',
+    segments: ['/users'],
     metadata: {
       GET: {
         responseType: 'User[]'
@@ -248,11 +249,10 @@ const schema = serializeRoutes('APISchema', [
     }
   },
   {
-    path: '/users/:id',
-    type: 'dynamic',
+    segments: ['/users', DynamicParam, '/posts'],
     metadata: {
       GET: {
-        responseType: 'User'
+        responseType: 'Post[]'
       }
     }
   }
@@ -261,6 +261,61 @@ const schema = serializeRoutes('APISchema', [
 console.log(schema)
 // Outputs TypeScript interface definition
 ```
+
+A segment is either static or a parameter:
+
+| Segment | Meaning |
+| --- | --- |
+| `'/users'`, `'users'`, `{ type: 'static', value: 'users' }` | a static segment |
+| `'https://api.example.com'` | an origin, for cross-domain schemas |
+| `DynamicParam`, `{ type: 'dynamic' }` | exactly one segment |
+| `WildcardParam`, `{ type: 'wildcard' }` | the rest of the path |
+
+The object form exists so that tools which cannot pass symbols across a serialisation boundary can
+still describe a route. Both forms produce identical output, and a static segment may itself contain
+slashes (`'/api/users'`), which keeps the emitted tree shallower.
+
+#### Converting route patterns
+
+`fetchdts` does not parse route patterns. Every router spells a parameter differently, and the
+schema only needs to know which segments are static, which match one segment, and which match the
+rest, so the conversion belongs to whichever tool already owns your patterns.
+
+If your patterns are [rou3](https://github.com/h3js/rou3) patterns, `routeNodeKeys` gives the
+canonical form directly, and gives it to you from the router that will serve the request, so the
+generated types cannot drift from the routing:
+
+```ts
+import { DynamicParam, serializeRoutes, WildcardParam } from 'fetchdts'
+import { routeNodeKeys } from 'rou3'
+
+const routes = endpoints.flatMap(({ pattern, method, responseType }) =>
+  // one pattern can land on several nodes: `/users/:id?` -> ['/users', '/users/*']
+  routeNodeKeys(pattern).map(key => ({
+    segments: key.split('/').slice(1).map(segment =>
+      segment === '*'
+        ? DynamicParam
+        : segment === '**'
+          ? WildcardParam
+          // escapes are preserved, so a literal `*` arrives as `\*`
+          : segment.replace(/\\(.)/g, '$1'),
+    ),
+    metadata: { [method]: { responseType } },
+  })),
+)
+
+const schema = serializeRoutes('APISchema', routes)
+```
+
+For an endpoint that is valid for every method, see
+[Handlers Registered for Every Method](#handlers-registered-for-every-method).
+
+For filesystem routes, [`unrouting`](https://github.com/unjs/unrouting) parses the major conventions
+and converts between them, reporting each lossy step rather than silently widening a pattern.
+
+Constrained parameters collapse onto one node: `/users/:id(\d+)` and `/users/:slug([a-z]+)` share a
+single dynamic segment in the schema, so their response types are unioned. Radix-tree routers group
+them the same way and re-check the constraint per node, which a type cannot do.
 
 ## Advanced Examples
 
@@ -332,6 +387,20 @@ await api('/api/users') // User[]
 await api('/api/users/123') // User
 await api('/api/users/123/posts') // Post[]
 await api('/api/users/123/posts/456') // Post
+```
+
+### Handlers Registered for Every Method
+
+A handler that is valid for every HTTP verb can be expressed compactly with `Record<HTTPMethod, ...>`:
+
+```ts
+interface APISchema {
+  '/api': {
+    '/hello': {
+      [Endpoint]: Record<HTTPMethod, { response: { hello: string } }>
+    }
+  }
+}
 ```
 
 ### Cross-Domain API Support

--- a/README.md
+++ b/README.md
@@ -470,6 +470,39 @@ else {
 
 ## Best Practices
 
+### Typing a Fetch Function
+
+Keep the init type in *parameter* position, and make the method a type parameter if the response
+needs to narrow by it:
+
+```ts
+declare function $fetch<T extends TypedFetchInput<Schema>, M extends HTTPMethod = 'GET'>(
+  input: T,
+  init?: TypedFetchRequestInit<Schema, T> & { method?: M },
+): TypedFetchResponseBody<Schema, Trimmed<T>, M>
+```
+
+Constraining a type parameter to the init type instead looks equivalent, but is not:
+
+```ts
+// avoid: `Init` is constrained by every path in the schema
+declare function $fetch<T extends TypedFetchInput<Schema>, Init extends TypedFetchRequestInit<Schema, T>>(
+  input: T,
+  init?: Init,
+): TypedFetchResponseBody<Schema, Trimmed<T>, Init['method'] extends HTTPMethod ? Init['method'] : 'GET'>
+```
+
+The constraint is instantiated with `T` as the whole path union, so the request init is computed for
+every route in the schema before a single call site is checked. On a schema of any size this
+dominates everything else: the cost stops tracking the number of call sites and starts tracking the
+number of routes, several times over. `pnpm bench --eager-init` measures the difference.
+
+Two smaller notes on the same signature. An endpoint declares the headers it *requires*, so add
+`{ headers?: Record<string, string> }` to the init if callers should be free to send others.
+And if some paths only accept a method other than `GET`, a second overload constrained to
+`TypedFetchInput<Schema, 'GET'>` with an optional init keeps those paths from being called without
+one.
+
 ### Schema Organization
 
 For large APIs, consider organizing your schemas into modules:

--- a/bench/instantiations.mjs
+++ b/bench/instantiations.mjs
@@ -1,6 +1,11 @@
 /* eslint-disable no-console */
 // Measures tsc type instantiations for a generated N-route schema.
 // Usage: node bench/instantiations.mjs [--routes 150] [--calls 60] [--depth 3] [--src ./src]
+//                                      [--siblings 0] [--template]
+//
+// --siblings adds N static routes alongside each dynamic one, and --template requests the dynamic
+// routes with a template literal (`/a/b/${string}`) rather than a concrete path, which together
+// measure what a template-literal request costs when its node has static siblings.
 
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
@@ -27,6 +32,8 @@ function count(name, fallback, minimum) {
 const routes = count('routes', 150, 1)
 const calls = count('calls', 60, 0)
 const depth = count('depth', 3, 1)
+const siblings = count('siblings', 0, 0)
+const template = args.includes('--template')
 const root = fileURLToPath(new URL('..', import.meta.url))
 const src = path.resolve(root, arg('src', 'src'))
 
@@ -46,13 +53,20 @@ for (let i = 0; i < routes; i++) {
     node[segment] ||= {}
     node = node[segment]
   }
+  const parent = node
   if (dynamic) {
     node['[DynamicParam]'] ||= {}
     node = node['[DynamicParam]']
   }
   node['[Endpoint]'] = `{ GET: { response: { id: number, route: '${i}' } }, POST: { body: { id: number }, response: { ok: true } } }`
 
-  paths.push(segments.join('') + (dynamic ? '/1' : ''))
+  if (dynamic) {
+    for (let sibling = 0; sibling < siblings; sibling++) {
+      parent[`/sibling${sibling}`] ||= { '[Endpoint]': `{ GET: { response: { sibling: ${sibling} } } }` }
+    }
+  }
+
+  paths.push({ prefix: segments.join(''), dynamic })
 }
 
 function stringify(node, indent = 2) {
@@ -71,17 +85,22 @@ const schema = stringify(tree)
 const dir = mkdtempSync(path.join(tmpdir(), 'fetchdts-bench-'))
 mkdirSync(dir, { recursive: true })
 
-// module specifiers always use forward slashes, including on Windows
-const specifier = name => path.join(src, name).replaceAll(path.sep, '/')
+// module specifiers always use forward slashes, including on Windows, and are quoted rather than
+// interpolated so that a project path containing a quote still emits valid TypeScript
+const specifier = name => JSON.stringify(path.join(src, name).replaceAll(path.sep, '/'))
 
-let source = `import type { DynamicParam, Endpoint } from '${specifier('tree')}'\n`
-source += `import type { TypedFetchInput, TypedFetchRequestInit, TypedFetchResponseBody } from '${specifier('inference')}'\n`
-source += `import type { Trimmed } from '${specifier('utils')}'\n\n`
+let source = `import type { DynamicParam, Endpoint } from ${specifier('tree')}\n`
+source += `import type { TypedFetchInput, TypedFetchRequestInit, TypedFetchResponseBody } from ${specifier('inference')}\n`
+source += `import type { Trimmed } from ${specifier('utils')}\n\n`
 source += `interface Schema {\n${schema}}\n\n`
 source += `declare function $fetch<T extends TypedFetchInput<Schema>, Init extends TypedFetchRequestInit<Schema, T>>(input: T, init?: Init): TypedFetchResponseBody<Schema, Trimmed<T>, 'GET'>\n\n`
+source += 'declare const param: string\n\n'
 for (let i = 0; i < calls; i++) {
-  const index = i % paths.length
-  source += `export const result${i} = $fetch('${paths[index]}')\n`
+  const { prefix, dynamic } = paths[i % paths.length]
+  const input = dynamic
+    ? template ? `\`${prefix}/\${param}\`` : `'${prefix}/1'`
+    : `'${prefix}'`
+  source += `export const result${i} = $fetch(${input})\n`
   // an unresolved path yields `never`, which would otherwise satisfy every annotation and make a broken matcher look cheap
   source += `const resolved${i}: true = 0 as unknown as [typeof result${i}] extends [never] ? false : true\n`
   source += `void resolved${i}\n`

--- a/bench/instantiations.mjs
+++ b/bench/instantiations.mjs
@@ -1,11 +1,14 @@
 /* eslint-disable no-console */
 // Measures tsc type instantiations for a generated N-route schema.
 // Usage: node bench/instantiations.mjs [--routes 150] [--calls 60] [--depth 3] [--src ./src]
-//                                      [--siblings 0] [--template] [--eager-init]
+//                                      [--siblings 0] [--template] [--ambiguous] [--eager-init]
 //
 // --siblings adds N static routes alongside each dynamic one, and --template requests the dynamic
 // routes with a template literal (`/a/b/${string}`) rather than a concrete path, which together
 // measure what a template-literal request costs when its node has static siblings.
+//
+// --ambiguous emits an `ambiguousResponse` on each dynamic endpoint, as a caller that precomputes
+// the union of its static siblings would, which is what a template-literal request then resolves to.
 //
 // --eager-init constrains a generic to the init type instead of using it in parameter position,
 // which forces the init to be computed for the whole path union before any call site is checked.
@@ -39,6 +42,7 @@ const calls = count('calls', 60, 0)
 const depth = count('depth', 3, 1)
 const siblings = count('siblings', 0, 0)
 const template = args.includes('--template')
+const ambiguous = args.includes('--ambiguous')
 const eagerInit = args.includes('--eager-init')
 const root = fileURLToPath(new URL('..', import.meta.url))
 const src = path.resolve(root, arg('src', 'src'))
@@ -64,7 +68,10 @@ for (let i = 0; i < routes; i++) {
     node['[DynamicParam]'] ||= {}
     node = node['[DynamicParam]']
   }
-  node['[Endpoint]'] = `{ GET: { response: { id: number, route: '${i}' } }, POST: { body: { id: number }, response: { ok: true } } }`
+  const overlapping = dynamic && ambiguous
+    ? `, ambiguousResponse: { id: number, route: '${i}' }${Array.from({ length: siblings }, (_, sibling) => ` | { sibling: ${sibling} }`).join('')}`
+    : ''
+  node['[Endpoint]'] = `{ GET: { response: { id: number, route: '${i}' }${overlapping} }, POST: { body: { id: number }, response: { ok: true } } }`
 
   if (dynamic) {
     for (let sibling = 0; sibling < siblings; sibling++) {
@@ -148,7 +155,7 @@ try {
   }
 
   const wanted = ['Instantiations', 'Types', 'Memory used', 'Total time', 'Check time']
-  console.log(`routes=${routes} calls=${calls} depth=${depth}${siblings > 0 ? ` siblings=${siblings}` : ''}${template ? ' template' : ''}${eagerInit ? ' eager-init' : ''} src=${path.relative(root, src) || 'src'}`)
+  console.log(`routes=${routes} calls=${calls} depth=${depth}${siblings > 0 ? ` siblings=${siblings}` : ''}${template ? ' template' : ''}${ambiguous ? ' ambiguous' : ''}${eagerInit ? ' eager-init' : ''} src=${path.relative(root, src) || 'src'}`)
   for (const line of output.split('\n')) {
     if (wanted.some(key => line.startsWith(key))) {
       console.log(`  ${line.trim()}`)

--- a/bench/instantiations.mjs
+++ b/bench/instantiations.mjs
@@ -1,11 +1,16 @@
 /* eslint-disable no-console */
 // Measures tsc type instantiations for a generated N-route schema.
 // Usage: node bench/instantiations.mjs [--routes 150] [--calls 60] [--depth 3] [--src ./src]
-//                                      [--siblings 0] [--template]
+//                                      [--siblings 0] [--template] [--eager-init]
 //
 // --siblings adds N static routes alongside each dynamic one, and --template requests the dynamic
 // routes with a template literal (`/a/b/${string}`) rather than a concrete path, which together
 // measure what a template-literal request costs when its node has static siblings.
+//
+// --eager-init constrains a generic to the init type instead of using it in parameter position,
+// which forces the init to be computed for the whole path union before any call site is checked.
+// It is the shape to avoid in a client, and is kept measurable because the cost is easy to
+// reintroduce by accident and dwarfs everything else.
 
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
@@ -34,6 +39,7 @@ const calls = count('calls', 60, 0)
 const depth = count('depth', 3, 1)
 const siblings = count('siblings', 0, 0)
 const template = args.includes('--template')
+const eagerInit = args.includes('--eager-init')
 const root = fileURLToPath(new URL('..', import.meta.url))
 const src = path.resolve(root, arg('src', 'src'))
 
@@ -90,10 +96,13 @@ mkdirSync(dir, { recursive: true })
 const specifier = name => JSON.stringify(path.join(src, name).replaceAll(path.sep, '/'))
 
 let source = `import type { DynamicParam, Endpoint } from ${specifier('tree')}\n`
+source += `import type { HTTPMethod } from ${specifier('http/index')}\n`
 source += `import type { TypedFetchInput, TypedFetchRequestInit, TypedFetchResponseBody } from ${specifier('inference')}\n`
 source += `import type { Trimmed } from ${specifier('utils')}\n\n`
 source += `interface Schema {\n${schema}}\n\n`
-source += `declare function $fetch<T extends TypedFetchInput<Schema>, Init extends TypedFetchRequestInit<Schema, T>>(input: T, init?: Init): TypedFetchResponseBody<Schema, Trimmed<T>, 'GET'>\n\n`
+source += eagerInit
+  ? `declare function $fetch<T extends TypedFetchInput<Schema>, Init extends TypedFetchRequestInit<Schema, T>>(input: T, init?: Init): TypedFetchResponseBody<Schema, Trimmed<T>, 'GET'>\n\n`
+  : `declare function $fetch<T extends TypedFetchInput<Schema>, M extends HTTPMethod = 'GET'>(input: T, init?: TypedFetchRequestInit<Schema, T> & { method?: M }): TypedFetchResponseBody<Schema, Trimmed<T>, M>\n\n`
 source += 'declare const param: string\n\n'
 for (let i = 0; i < calls; i++) {
   const { prefix, dynamic } = paths[i % paths.length]
@@ -139,7 +148,7 @@ try {
   }
 
   const wanted = ['Instantiations', 'Types', 'Memory used', 'Total time', 'Check time']
-  console.log(`routes=${routes} calls=${calls} depth=${depth} src=${path.relative(root, src) || 'src'}`)
+  console.log(`routes=${routes} calls=${calls} depth=${depth}${siblings > 0 ? ` siblings=${siblings}` : ''}${template ? ' template' : ''}${eagerInit ? ' eager-init' : ''} src=${path.relative(root, src) || 'src'}`)
   for (const line of output.split('\n')) {
     if (wanted.some(key => line.startsWith(key))) {
       console.log(`  ${line.trim()}`)

--- a/bench/instantiations.mjs
+++ b/bench/instantiations.mjs
@@ -3,7 +3,7 @@
 // Usage: node bench/instantiations.mjs [--routes 150] [--calls 60] [--depth 3] [--src ./src]
 
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
@@ -15,9 +15,18 @@ function arg(name, fallback) {
   return index === -1 ? fallback : args[index + 1]
 }
 
-const routes = Number(arg('routes', 150))
-const calls = Number(arg('calls', 60))
-const depth = Number(arg('depth', 3))
+function count(name, fallback, minimum) {
+  const value = Number(arg(name, fallback))
+  if (!Number.isInteger(value) || value < minimum) {
+    console.error(`--${name} must be an integer >= ${minimum}, received ${arg(name, fallback)}`)
+    process.exit(1)
+  }
+  return value
+}
+
+const routes = count('routes', 150, 1)
+const calls = count('calls', 60, 0)
+const depth = count('depth', 3, 1)
 const root = fileURLToPath(new URL('..', import.meta.url))
 const src = path.resolve(root, arg('src', 'src'))
 
@@ -62,9 +71,12 @@ const schema = stringify(tree)
 const dir = mkdtempSync(path.join(tmpdir(), 'fetchdts-bench-'))
 mkdirSync(dir, { recursive: true })
 
-let source = `import type { DynamicParam, Endpoint } from '${path.join(src, 'tree')}'\n`
-source += `import type { TypedFetchInput, TypedFetchRequestInit, TypedFetchResponseBody } from '${path.join(src, 'inference')}'\n`
-source += `import type { Trimmed } from '${path.join(src, 'utils')}'\n\n`
+// module specifiers always use forward slashes, including on Windows
+const specifier = name => path.join(src, name).replaceAll(path.sep, '/')
+
+let source = `import type { DynamicParam, Endpoint } from '${specifier('tree')}'\n`
+source += `import type { TypedFetchInput, TypedFetchRequestInit, TypedFetchResponseBody } from '${specifier('inference')}'\n`
+source += `import type { Trimmed } from '${specifier('utils')}'\n\n`
 source += `interface Schema {\n${schema}}\n\n`
 source += `declare function $fetch<T extends TypedFetchInput<Schema>, Init extends TypedFetchRequestInit<Schema, T>>(input: T, init?: Init): TypedFetchResponseBody<Schema, Trimmed<T>, 'GET'>\n\n`
 for (let i = 0; i < calls; i++) {
@@ -90,21 +102,31 @@ writeFileSync(path.join(dir, 'tsconfig.json'), JSON.stringify({
   include: ['index.ts'],
 }, null, 2))
 
-const tsc = path.join(root, 'node_modules/.bin/tsc')
-let output
-try {
-  output = execFileSync(tsc, ['-p', dir, '--extendedDiagnostics'], { encoding: 'utf8' })
-}
-catch (error) {
-  output = error.stdout
-  const errors = output.split('\n').filter(line => line.includes(': error TS'))
-  console.error(`${errors.length} type errors in generated fixture, first:\n${errors[0]}`)
-}
+// the `.bin` shim is a `.cmd` file on Windows, which `execFileSync` cannot run directly
+const tsc = path.join(root, 'node_modules/typescript/bin/tsc')
 
-const wanted = ['Instantiations', 'Types', 'Memory used', 'Total time', 'Check time']
-console.log(`routes=${routes} calls=${calls} depth=${depth} src=${path.relative(root, src) || 'src'}`)
-for (const line of output.split('\n')) {
-  if (wanted.some(key => line.startsWith(key))) {
-    console.log(`  ${line.trim()}`)
+try {
+  let output
+  try {
+    output = execFileSync(process.execPath, [tsc, '-p', dir, '--extendedDiagnostics'], { encoding: 'utf8' })
   }
+  catch (error) {
+    output = error.stdout || ''
+    const errors = output.split('\n').filter(line => line.includes(': error TS'))
+    console.error(errors.length > 0
+      ? `${errors.length} type errors in generated fixture, first:\n${errors[0]}`
+      : `tsc failed without diagnostics:\n${error.stderr || error.message}`)
+    process.exitCode = 1
+  }
+
+  const wanted = ['Instantiations', 'Types', 'Memory used', 'Total time', 'Check time']
+  console.log(`routes=${routes} calls=${calls} depth=${depth} src=${path.relative(root, src) || 'src'}`)
+  for (const line of output.split('\n')) {
+    if (wanted.some(key => line.startsWith(key))) {
+      console.log(`  ${line.trim()}`)
+    }
+  }
+}
+finally {
+  rmSync(dir, { recursive: true, force: true })
 }

--- a/bench/instantiations.mjs
+++ b/bench/instantiations.mjs
@@ -1,0 +1,110 @@
+/* eslint-disable no-console */
+// Measures tsc type instantiations for a generated N-route schema.
+// Usage: node bench/instantiations.mjs [--routes 150] [--calls 60] [--depth 3] [--src ./src]
+
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const args = process.argv.slice(2)
+function arg(name, fallback) {
+  const index = args.indexOf(`--${name}`)
+  return index === -1 ? fallback : args[index + 1]
+}
+
+const routes = Number(arg('routes', 150))
+const calls = Number(arg('calls', 60))
+const depth = Number(arg('depth', 3))
+const root = fileURLToPath(new URL('..', import.meta.url))
+const src = path.resolve(root, arg('src', 'src'))
+
+const paths = []
+const tree = {}
+for (let i = 0; i < routes; i++) {
+  const segments = []
+  for (let level = 0; level < depth - 1; level++) {
+    segments.push(`/group${(i + level) % 8}`)
+  }
+  segments.push(`/route${i}`)
+
+  const dynamic = i % 3 === 0
+
+  let node = tree
+  for (const segment of segments) {
+    node[segment] ||= {}
+    node = node[segment]
+  }
+  if (dynamic) {
+    node['[DynamicParam]'] ||= {}
+    node = node['[DynamicParam]']
+  }
+  node['[Endpoint]'] = `{ GET: { response: { id: number, route: '${i}' } }, POST: { body: { id: number }, response: { ok: true } } }`
+
+  paths.push(segments.join('') + (dynamic ? '/1' : ''))
+}
+
+function stringify(node, indent = 2) {
+  let output = ''
+  for (const [key, value] of Object.entries(node)) {
+    const name = key.startsWith('[') ? key : `'${key}'`
+    output += typeof value === 'string'
+      ? `${' '.repeat(indent)}${name}: ${value}\n`
+      : `${' '.repeat(indent)}${name}: {\n${stringify(value, indent + 2)}${' '.repeat(indent)}}\n`
+  }
+  return output
+}
+
+const schema = stringify(tree)
+
+const dir = mkdtempSync(path.join(tmpdir(), 'fetchdts-bench-'))
+mkdirSync(dir, { recursive: true })
+
+let source = `import type { DynamicParam, Endpoint } from '${path.join(src, 'tree')}'\n`
+source += `import type { TypedFetchInput, TypedFetchRequestInit, TypedFetchResponseBody } from '${path.join(src, 'inference')}'\n`
+source += `import type { Trimmed } from '${path.join(src, 'utils')}'\n\n`
+source += `interface Schema {\n${schema}}\n\n`
+source += `declare function $fetch<T extends TypedFetchInput<Schema>, Init extends TypedFetchRequestInit<Schema, T>>(input: T, init?: Init): TypedFetchResponseBody<Schema, Trimmed<T>, 'GET'>\n\n`
+for (let i = 0; i < calls; i++) {
+  const index = i % paths.length
+  source += `export const result${i} = $fetch('${paths[index]}')\n`
+  // an unresolved path yields `never`, which would otherwise satisfy every annotation and make a broken matcher look cheap
+  source += `const resolved${i}: true = 0 as unknown as [typeof result${i}] extends [never] ? false : true\n`
+  source += `void resolved${i}\n`
+}
+
+writeFileSync(path.join(dir, 'index.ts'), source)
+writeFileSync(path.join(dir, 'tsconfig.json'), JSON.stringify({
+  compilerOptions: {
+    strict: true,
+    target: 'es2022',
+    lib: ['DOM', 'es2022'],
+    module: 'preserve',
+    moduleResolution: 'bundler',
+    noEmit: true,
+    skipLibCheck: true,
+    types: [],
+  },
+  include: ['index.ts'],
+}, null, 2))
+
+const tsc = path.join(root, 'node_modules/.bin/tsc')
+let output
+try {
+  output = execFileSync(tsc, ['-p', dir, '--extendedDiagnostics'], { encoding: 'utf8' })
+}
+catch (error) {
+  output = error.stdout
+  const errors = output.split('\n').filter(line => line.includes(': error TS'))
+  console.error(`${errors.length} type errors in generated fixture, first:\n${errors[0]}`)
+}
+
+const wanted = ['Instantiations', 'Types', 'Memory used', 'Total time', 'Check time']
+console.log(`routes=${routes} calls=${calls} depth=${depth} src=${path.relative(root, src) || 'src'}`)
+for (const line of output.split('\n')) {
+  if (wanted.some(key => line.startsWith(key))) {
+    console.log(`  ${line.trim()}`)
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,8 @@
 import antfu from '@antfu/eslint-config'
 
-export default antfu()
+export default antfu({
+  ignores: ['test/fixture/generated.ts'],
+})
   .append({
     files: ['playground/**'],
     rules: {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     }
   },
   "scripts": {
+    "bench": "node bench/instantiations.mjs",
     "build": "tsdown",
     "dev": "vitest dev",
     "lint": "eslint .",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ export type { TypedFetchInput, TypedFetchMeta, TypedFetchPath, TypedFetchRequest
 
 export { serializeRoutes } from './serialize'
 
-export type { Route } from './serialize'
+export type { Route, RouteSegment } from './serialize'
 
 export type { Endpoints, RouteTree } from './tree'
 
-export type { DynamicParam, Endpoint, WildcardParam } from './tree'
+export { DynamicParam, Endpoint, WildcardParam } from './tree'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export type { HTTPMethod, MimeType, RequestHeaderMap, RequestHeaderName, Request
 
 export type { TypedURLSearchParams } from './http/url'
 
-export type { TypedFetchInput, TypedFetchMeta, TypedFetchPath, TypedFetchRequestInit, TypedFetchResolvedMeta, TypedFetchResponseBody as TypedFetchResponse, TypedFetchResponseBody } from './inference'
+export type { MatchPattern, TypedFetchInput, TypedFetchMeta, TypedFetchPath, TypedFetchRequestInit, TypedFetchResolvedMeta, TypedFetchResponseBody as TypedFetchResponse, TypedFetchResponseBody } from './inference'
 
 export { serializeRoutes } from './serialize'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export type { HTTPMethod, MimeType, RequestHeaderMap, RequestHeaderName, Request
 
 export type { TypedURLSearchParams } from './http/url'
 
-export type { TypedFetchInput, TypedFetchMeta, TypedFetchPath, TypedFetchRequestInit, TypedFetchResponseBody as TypedFetchResponse, TypedFetchResponseBody } from './inference'
+export type { TypedFetchInput, TypedFetchMeta, TypedFetchPath, TypedFetchRequestInit, TypedFetchResolvedMeta, TypedFetchResponseBody as TypedFetchResponse, TypedFetchResponseBody } from './inference'
 
 export { serializeRoutes } from './serialize'
 

--- a/src/inference.ts
+++ b/src/inference.ts
@@ -76,9 +76,9 @@ type ParamMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pat
   [K in keyof Schema]: K extends typeof DynamicParam
     ? TypedFetchMeta<Schema[K], AfterSegment<Path>, Method, LiteralSegment<Path> extends false ? 'ambiguous' : Pattern>
     : K extends typeof WildcardParam
-      ? [NonEmptySegments<Path>] extends [never]
-          ? never
-          : TypedFetchMeta<Schema[K], '', Method, Pattern>
+      ? HasSegment<Path> extends true
+        ? TypedFetchMeta<Schema[K], '', Method, Pattern>
+        : never
       : never
 }[keyof Schema]
 
@@ -113,13 +113,18 @@ type LiteralSegment<Path extends string>
       : string extends Rest ? false : true
     : true
 
-/** `Path` itself if it contains at least one non-empty segment, otherwise `never`. */
-type NonEmptySegments<Path extends string>
+/**
+ * Whether `Path` contains at least one non-empty segment, which a wildcard requires to match.
+ * Repeated slashes contribute no segment, so `'//'` is as empty as `'/'`.
+ */
+type HasSegment<Path extends string>
   = Path extends `/${infer Rest}`
     ? Rest extends ''
-      ? never
-      : Path
-    : never
+      ? false
+      : Rest extends `/${string}`
+        ? HasSegment<Rest>
+        : true
+    : false
 
 /** The remainder of `Path` after consuming a single non-empty segment. */
 type AfterSegment<Path extends string>

--- a/src/inference.ts
+++ b/src/inference.ts
@@ -153,10 +153,17 @@ export type TypedFetchMeta<Schema, Path, Method extends HTTPMethod | '' = '', Pa
         : StaticMatch<Schema, Path, Method, Pattern>
       : never
 
+/**
+ * The response body for a path, or `unknown` where the endpoint exists but declares no response, so
+ * that a route registered without a return type stays callable. A path that matches nothing, or a
+ * method the endpoint does not register, is still `never`.
+ */
 export type TypedFetchResponseBody<Schema, Endpoint, Method extends HTTPMethod = 'GET'>
   = 'response' extends keyof TypedFetchResolvedMeta<Schema, Endpoint, Method>
     ? TypedFetchResolvedMeta<Schema, Endpoint, Method>['response']
-    : never
+    : [TypedFetchResolvedMeta<Schema, Endpoint, Method>] extends [never]
+        ? never
+        : unknown
 
 export type TypedFetchResponseHeaders<Schema, Endpoint, Method extends HTTPMethod = 'GET'>
   = 'responseHeaders' extends keyof TypedFetchResolvedMeta<Schema, Endpoint, Method>

--- a/src/inference.ts
+++ b/src/inference.ts
@@ -51,8 +51,19 @@ type RequestInitFor<Meta> = {
 
 export type TypedFetchRequestInit<Schema, T> = RequestInitFor<TypedFetchResolvedMeta<Schema, T>>
 
+/**
+ * How a path is matched against a schema.
+ *
+ * - `exact`: static segments only.
+ * - `dynamic`: parameters are considered where no static segment matches.
+ * - `ambiguous`: as `dynamic`, but a parameter has consumed a segment that is not a literal, so the
+ *   request could also have matched a static sibling and {@link EndpointMetadata.ambiguousResponse}
+ *   is preferred where an endpoint declares one.
+ */
+export type MatchPattern = 'exact' | 'dynamic' | 'ambiguous'
+
 /** Endpoints reached by matching `Path` against the static keys of `Schema`. */
-type StaticMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pattern extends 'exact' | 'dynamic'> = {
+type StaticMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pattern extends MatchPattern> = {
   [K in keyof Schema]: K extends StaticParam
     ? Path extends `${K}${infer Rest}`
       ? TypedFetchMeta<Schema[K], Rest, Method, Pattern>
@@ -61,9 +72,9 @@ type StaticMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pa
 }[keyof Schema]
 
 /** Endpoints reached by consuming a segment of `Path` with a dynamic or wildcard parameter. */
-type ParamMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pattern extends 'exact' | 'dynamic'> = {
+type ParamMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pattern extends MatchPattern> = {
   [K in keyof Schema]: K extends typeof DynamicParam
-    ? TypedFetchMeta<Schema[K], AfterSegment<Path>, Method, Pattern>
+    ? TypedFetchMeta<Schema[K], AfterSegment<Path>, Method, LiteralSegment<Path> extends false ? 'ambiguous' : Pattern>
     : K extends typeof WildcardParam
       ? [NonEmptySegments<Path>] extends [never]
           ? never
@@ -75,12 +86,32 @@ type ParamMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pat
  * Metadata for the endpoints registered directly on a node, narrowed by `Method`
  * when one is provided.
  */
-type EndpointMeta<Endpoints, Method extends HTTPMethod | ''>
+type EndpointMeta<Endpoints, Method extends HTTPMethod | '', Pattern extends MatchPattern>
   = '' extends Method
-    ? { [M in keyof Endpoints]: { method: M } & Endpoints[M] }[keyof Endpoints]
+    ? { [M in keyof Endpoints]: { method: M } & Ambiguate<Endpoints[M], Pattern> }[keyof Endpoints]
     : Method extends keyof Endpoints
-      ? Endpoints[Method] & { method: Method }
+      ? Ambiguate<Endpoints[Method], Pattern> & { method: Method }
       : never
+
+/**
+ * Replaces `response` with `ambiguousResponse` where the walk reached the endpoint through a
+ * parameter that consumed a segment known only at runtime, and the endpoint declares one. Endpoints
+ * without an `ambiguousResponse` are returned untouched, so this is inert until one is emitted.
+ */
+type Ambiguate<Metadata, Pattern extends MatchPattern>
+  = Pattern extends 'ambiguous'
+    ? 'ambiguousResponse' extends keyof Metadata
+      ? { [K in Exclude<keyof Metadata, 'ambiguousResponse'>]: K extends 'response' ? Metadata['ambiguousResponse'] : Metadata[K] }
+      : Metadata
+    : Metadata
+
+/** Whether the segment `Path` is about to consume is a literal rather than `string`-like. */
+type LiteralSegment<Path extends string>
+  = Path extends `/${infer Rest}`
+    ? Rest extends `${infer Head}/${string}`
+      ? string extends Head ? false : true
+      : string extends Rest ? false : true
+    : true
 
 /** `Path` itself if it contains at least one non-empty segment, otherwise `never`. */
 type NonEmptySegments<Path extends string>
@@ -104,13 +135,13 @@ type AfterSegment<Path extends string>
         : ''
     : never
 
-export type TypedFetchMeta<Schema, Path, Method extends HTTPMethod | '' = '', Pattern extends 'exact' | 'dynamic' = 'exact'>
+export type TypedFetchMeta<Schema, Path, Method extends HTTPMethod | '' = '', Pattern extends MatchPattern = 'exact'>
   = Path extends ''
     ? typeof Endpoint extends keyof Schema
-      ? EndpointMeta<Schema[typeof Endpoint], Method>
+      ? EndpointMeta<Schema[typeof Endpoint], Method, Pattern>
       : never
     : Path extends string
-      ? Pattern extends 'dynamic'
+      ? Pattern extends 'dynamic' | 'ambiguous'
         ? [StaticMatch<Schema, Path, Method, Pattern>] extends [never]
             ? ParamMatch<Schema, Path, Method, Pattern>
             : StaticMatch<Schema, Path, Method, Pattern>

--- a/src/inference.ts
+++ b/src/inference.ts
@@ -41,37 +41,61 @@ export type TypedFetchRequestInit<Schema, T> = {
     : { method?: RequestInit['method'] }
 ) & RespectOptionality<TypedFetchMeta<Schema, T>, 'body', RequestInit['body']>
 
-export type TypedFetchMeta<Schema, Path, Method extends HTTPMethod | '' = '', Pattern extends 'exact' | 'dynamic' = 'exact'> = {
-  [K in keyof Schema]: K extends typeof Endpoint
-    ? '' extends Method
-      ? { [M in keyof Schema[K]]: { method: M } & Schema[K][M] }[keyof Schema[K]]
-      : Method extends keyof Schema[K]
-        ? Schema[K][Method] & { method: Method }
-        : never
-    : Path extends K
-      ? TypedFetchMeta<Schema[K], Path, Method, Pattern>
-      : K extends StaticParam
-        ? Path extends `${K}${infer Rest}`
-          ? Rest extends keyof Schema[K]
-            ? Pattern extends 'dynamic'
-              ? typeof DynamicParam extends keyof Schema[K]
-                ? Path extends `${string}${string}/${infer Additional}`
-                  ? TypedFetchMeta<Schema[K][typeof DynamicParam], Additional, Method, Pattern> | TypedFetchMeta<Schema[K][Rest], Rest, Method, Pattern>
-                  : never
-                : typeof WildcardParam extends keyof Schema[K]
-                  ? TypedFetchMeta<Schema[K][typeof WildcardParam], '', Method, Pattern> | TypedFetchMeta<Schema[K][Rest], Rest, Method, Pattern>
-                  : never
-              : TypedFetchMeta<Schema[K][Rest], Rest, Method, Pattern>
-            : typeof DynamicParam extends keyof Schema[K]
-              ? Path extends `${string}${string}/${infer Rest}`
-                ? TypedFetchMeta<Schema[K][typeof DynamicParam], Rest, Method, Pattern>
-                : never
-              : typeof WildcardParam extends keyof Schema[K]
-                ? TypedFetchMeta<Schema[K][typeof WildcardParam], '', Method, Pattern>
-                : never
+/**
+ * Metadata for the endpoints registered directly on a node, narrowed by `Method`
+ * when one is provided.
+ */
+type EndpointMeta<Endpoints, Method extends HTTPMethod | ''>
+  = '' extends Method
+    ? { [M in keyof Endpoints]: { method: M } & Endpoints[M] }[keyof Endpoints]
+    : Method extends keyof Endpoints
+      ? Endpoints[Method] & { method: Method }
+      : never
+
+/** `Path` itself if it contains at least one non-empty segment, otherwise `never`. */
+type NonEmptySegments<Path extends string>
+  = Path extends `/${infer Rest}`
+    ? Rest extends ''
+      ? never
+      : Path
+    : Path
+
+/** The remainder of `Path` after consuming a single non-empty segment. */
+type AfterSegment<Path extends string>
+  = Path extends `/${infer Rest}`
+    ? Rest extends `${infer Head}/${string}`
+      ? Head extends ''
+        ? never
+        : Path extends `/${Head}${infer Tail}`
+          ? Tail
           : never
-        : never
-}[keyof Schema]
+      : Rest extends ''
+        ? never
+        : ''
+    : never
+
+export type TypedFetchMeta<Schema, Path, Method extends HTTPMethod | '' = '', Pattern extends 'exact' | 'dynamic' = 'exact'>
+  = Path extends ''
+    ? typeof Endpoint extends keyof Schema
+      ? EndpointMeta<Schema[typeof Endpoint], Method>
+      : never
+    : Path extends string
+      ? {
+          [K in keyof Schema]: K extends StaticParam
+            ? Path extends `${K}${infer Rest}`
+              ? TypedFetchMeta<Schema[K], Rest, Method, Pattern>
+              : never
+            : Pattern extends 'dynamic'
+              ? K extends typeof DynamicParam
+                ? TypedFetchMeta<Schema[K], AfterSegment<Path>, Method, Pattern>
+                : K extends typeof WildcardParam
+                  ? NonEmptySegments<Path> extends never
+                    ? never
+                    : TypedFetchMeta<Schema[K], '', Method, Pattern>
+                  : never
+              : never
+        }[keyof Schema]
+      : never
 
 export type TypedFetchResponseBody<Schema, Endpoint, Method extends HTTPMethod = 'GET'>
   = TypedFetchMeta<Schema, Endpoint, Method> extends never

--- a/src/inference.ts
+++ b/src/inference.ts
@@ -88,7 +88,7 @@ type NonEmptySegments<Path extends string>
     ? Rest extends ''
       ? never
       : Path
-    : Path
+    : never
 
 /** The remainder of `Path` after consuming a single non-empty segment. */
 type AfterSegment<Path extends string>

--- a/src/inference.ts
+++ b/src/inference.ts
@@ -27,19 +27,49 @@ export type TypedFetchPath<Schema, Base extends string = '', Method = ''> = {
           : never
 }[keyof Schema]
 
+/**
+ * Metadata for the endpoint `Path` resolves to, including endpoints reached through a dynamic or
+ * wildcard parameter. This is the lookup a router performs; {@link TypedFetchMeta} on its own
+ * considers static segments only.
+ */
+export type TypedFetchResolvedMeta<Schema, Path, Method extends HTTPMethod | '' = ''>
+  = TypedFetchMeta<Schema, Path, Method, 'dynamic'>
+
 // TODO: optimise me
-export type TypedFetchRequestInit<Schema, T> = {
-  [K in keyof Omit<RequestInit, 'method' | 'body'>]?: K extends keyof TypedFetchMeta<Schema, T>
-    ? TypedFetchMeta<Schema, T>[K]
+type RequestInitFor<Meta> = {
+  [K in keyof Omit<RequestInit, 'method' | 'body'>]?: K extends keyof Meta
+    ? Meta[K]
     : RequestInit[K]
 } & (
-  'method' extends keyof TypedFetchMeta<Schema, T>
+  'method' extends keyof Meta
     // if GET is a valid method we don't require method to be specified
-    ? 'GET' extends TypedFetchMeta<Schema, T>['method']
-      ? { method?: TypedFetchMeta<Schema, T>['method'] }
-      : { method: TypedFetchMeta<Schema, T>['method'] }
+    ? 'GET' extends Meta['method']
+      ? { method?: Meta['method'] }
+      : { method: Meta['method'] }
     : { method?: RequestInit['method'] }
-) & RespectOptionality<TypedFetchMeta<Schema, T>, 'body', RequestInit['body']>
+) & RespectOptionality<Meta, 'body', RequestInit['body']>
+
+export type TypedFetchRequestInit<Schema, T> = RequestInitFor<TypedFetchResolvedMeta<Schema, T>>
+
+/** Endpoints reached by matching `Path` against the static keys of `Schema`. */
+type StaticMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pattern extends 'exact' | 'dynamic'> = {
+  [K in keyof Schema]: K extends StaticParam
+    ? Path extends `${K}${infer Rest}`
+      ? TypedFetchMeta<Schema[K], Rest, Method, Pattern>
+      : never
+    : never
+}[keyof Schema]
+
+/** Endpoints reached by consuming a segment of `Path` with a dynamic or wildcard parameter. */
+type ParamMatch<Schema, Path extends string, Method extends HTTPMethod | '', Pattern extends 'exact' | 'dynamic'> = {
+  [K in keyof Schema]: K extends typeof DynamicParam
+    ? TypedFetchMeta<Schema[K], AfterSegment<Path>, Method, Pattern>
+    : K extends typeof WildcardParam
+      ? [NonEmptySegments<Path>] extends [never]
+          ? never
+          : TypedFetchMeta<Schema[K], '', Method, Pattern>
+      : never
+}[keyof Schema]
 
 /**
  * Metadata for the endpoints registered directly on a node, narrowed by `Method`
@@ -80,37 +110,19 @@ export type TypedFetchMeta<Schema, Path, Method extends HTTPMethod | '' = '', Pa
       ? EndpointMeta<Schema[typeof Endpoint], Method>
       : never
     : Path extends string
-      ? {
-          [K in keyof Schema]: K extends StaticParam
-            ? Path extends `${K}${infer Rest}`
-              ? TypedFetchMeta<Schema[K], Rest, Method, Pattern>
-              : never
-            : Pattern extends 'dynamic'
-              ? K extends typeof DynamicParam
-                ? TypedFetchMeta<Schema[K], AfterSegment<Path>, Method, Pattern>
-                : K extends typeof WildcardParam
-                  ? NonEmptySegments<Path> extends never
-                    ? never
-                    : TypedFetchMeta<Schema[K], '', Method, Pattern>
-                  : never
-              : never
-        }[keyof Schema]
+      ? Pattern extends 'dynamic'
+        ? [StaticMatch<Schema, Path, Method, Pattern>] extends [never]
+            ? ParamMatch<Schema, Path, Method, Pattern>
+            : StaticMatch<Schema, Path, Method, Pattern>
+        : StaticMatch<Schema, Path, Method, Pattern>
       : never
 
 export type TypedFetchResponseBody<Schema, Endpoint, Method extends HTTPMethod = 'GET'>
-  = TypedFetchMeta<Schema, Endpoint, Method> extends never
-    ? 'response' extends keyof TypedFetchMeta<Schema, Endpoint, Method, 'dynamic'>
-      ? TypedFetchMeta<Schema, Endpoint, Method, 'dynamic'>['response']
-      : never
-    : 'response' extends keyof TypedFetchMeta<Schema, Endpoint, Method>
-      ? TypedFetchMeta<Schema, Endpoint, Method>['response']
-      : never
+  = 'response' extends keyof TypedFetchResolvedMeta<Schema, Endpoint, Method>
+    ? TypedFetchResolvedMeta<Schema, Endpoint, Method>['response']
+    : never
 
 export type TypedFetchResponseHeaders<Schema, Endpoint, Method extends HTTPMethod = 'GET'>
-  = TypedFetchMeta<Schema, Endpoint, Method> extends never
-    ? 'responseHeaders' extends keyof TypedFetchMeta<Schema, Endpoint, Method, 'dynamic'>
-      ? TypedFetchMeta<Schema, Endpoint, Method, 'dynamic'>['responseHeaders']
-      : never
-    : 'responseHeaders' extends keyof TypedFetchMeta<Schema, Endpoint, Method>
-      ? TypedFetchMeta<Schema, Endpoint, Method>['responseHeaders']
-      : never
+  = 'responseHeaders' extends keyof TypedFetchResolvedMeta<Schema, Endpoint, Method>
+    ? TypedFetchResolvedMeta<Schema, Endpoint, Method>['responseHeaders']
+    : never

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,15 +1,33 @@
 import type { HTTPMethod } from './http'
 import type { EndpointMetadata, RouteTree } from './tree'
-import { DynamicParam, WildcardParam } from './tree'
+import { DynamicParam, Endpoint, WildcardParam } from './tree'
 
 interface OutputOptions {
   /** whether to export the generated interface */
   export?: boolean
 }
 
+/**
+ * A single segment of a route.
+ *
+ * Static segments may be written with or without a leading slash (`'/users'`, `'users'`), or as an
+ * origin (`'https://api.example.com'`). Parameters are either the exported symbols, for schemas
+ * written by hand, or the plain object form, which survives serialisation across a tool boundary.
+ */
+export type RouteSegment
+  = | string
+    | typeof DynamicParam
+    | typeof WildcardParam
+    | { type: 'static', value: string }
+    | { type: 'dynamic' }
+    | { type: 'wildcard' }
+
 export interface Route {
-  type?: 'static' | 'dynamic' | 'wildcard'
-  path: string
+  /**
+   * The route, already split into segments. `fetchdts` does not parse route patterns; convert them
+   * with whichever tool owns them (see the readme).
+   */
+  segments: RouteSegment[]
   metadata?: {
     [key in HTTPMethod]?: Partial<Record<`${keyof EndpointMetadata}Type`, string>>
   }
@@ -22,44 +40,34 @@ export function serializeRoutes(name: string, routes: Route[], options?: OutputO
 
   // build route tree
   for (const route of routes) {
-    const { segments } = parsePath(route.path)
-
     let node: RouteTree = tree
-    for (const segment of segments) {
-      node[segment] = node[segment] || {}
-      node = node[segment] as RouteTree
+    for (const segment of route.segments) {
+      const key = segmentKey(segment)
+      if (typeof key === 'symbol') {
+        imports.add(key === DynamicParam ? 'DynamicParam' : 'WildcardParam')
+      }
+      node[key] = node[key] || {}
+      node = node[key] as RouteTree
     }
 
-    if (route.type === 'dynamic') {
-      imports.add('DynamicParam')
+    imports.add('Endpoint')
 
-      node[DynamicParam] = node[DynamicParam] || {}
-      node = node[DynamicParam] as RouteTree
-    }
-    if (route.type === 'wildcard') {
-      imports.add('WildcardParam')
-
-      node[WildcardParam] = node[WildcardParam] || {}
-      node = node[WildcardParam] as RouteTree
-    }
-
-    Object.assign(node, route.metadata)
+    node[Endpoint] = Object.assign((node[Endpoint] as RouteTree) || {}, route.metadata)
   }
 
   // stringify resulting tree
   return [
-    imports.size > 0 ? `import { ${[...imports].join(', ')} } from 'fetchdts'` : undefined,
-    options?.export ? 'export ' : undefined,
-    '',
-    `interface ${name} {\n${stringifyRouteTree(tree)}}`,
+    imports.size > 0 ? `import type { ${[...imports].sort().join(', ')} } from 'fetchdts'\n` : undefined,
+    `${options?.export ? 'export ' : ''}interface ${name} {\n${stringifyRouteTree(tree)}}`,
   ].filter(s => s !== undefined).join('\n')
 }
 
-const symbols = [DynamicParam, WildcardParam] as const
+const symbols = [DynamicParam, WildcardParam, Endpoint] as const
 
 const keys: Record<symbol | string, string> = {
   [DynamicParam]: '[DynamicParam]',
   [WildcardParam]: '[WildcardParam]',
+  [Endpoint]: '[Endpoint]',
 }
 
 function stringifyRouteTree(tree: RouteTree, indent = 2): string {
@@ -85,20 +93,24 @@ function stringifyRouteTree(tree: RouteTree, indent = 2): string {
   return properties
 }
 
-function parsePath(path: string): { segments: string[] } {
-  const url = new URL(path, 'http://localhost')
-  const segments = url.pathname.split('/').map(s => s.replace(/^\/?/, '/'))
-  if (segments[0] === '/' && segments.length > 1) {
-    segments.shift()
+function segmentKey(segment: RouteSegment): string | symbol {
+  if (typeof segment === 'string') {
+    return staticKey(segment)
   }
-
-  segments[segments.length - 1] += url.search + url.hash
-
-  if (!/^https?:\/\/localhost/.test(path) && url.host === 'localhost') {
-    return { segments }
+  if (typeof segment === 'symbol') {
+    return segment
   }
+  switch (segment.type) {
+    case 'dynamic': return DynamicParam
+    case 'wildcard': return WildcardParam
+    case 'static': return staticKey(segment.value)
+  }
+}
 
-  segments.unshift(url.origin)
-
-  return { segments }
+function staticKey(value: string): string {
+  // origins are matched as a single leading segment, so they keep their scheme instead of gaining a slash
+  if (value.includes('://') || value.startsWith('/')) {
+    return value
+  }
+  return `/${value}`
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -56,22 +56,27 @@ export function serializeRoutes(name: string, routes: Route[], options?: OutputO
     }
 
     // an endpoint with no methods would be offered as a valid path but resolve to `never`, so a
-    // route without metadata contributes its segments and nothing else
-    if (!route.metadata) {
+    // route with no method metadata contributes its segments and nothing else
+    const methods = Object.entries(route.metadata || {})
+      .filter((entry): entry is [string, Record<string, string>] => entry[1] !== undefined)
+    if (methods.length === 0) {
       continue
     }
 
     imports.add('Endpoint')
-    if ('ALL' in route.metadata) {
+    if (methods.some(([method]) => method === 'ALL')) {
       imports.add('HTTPMethod')
     }
 
     // distinct patterns can share a node, such as two parameters distinguished only by a constraint
     // the schema cannot express, so types are collected per field rather than overwritten
     const endpoints = (node[Endpoint] = (node[Endpoint] as RouteTree) || {}) as Record<string, Record<string, string[]>>
-    for (const [method, metadata] of Object.entries(route.metadata)) {
+    for (const [method, metadata] of methods) {
       const existing = endpoints[method] = endpoints[method] || {}
-      for (const [field, type] of Object.entries(metadata as Record<string, string>)) {
+      for (const [field, type] of Object.entries(metadata)) {
+        if (type === undefined) {
+          continue
+        }
         const types = existing[field] = existing[field] || []
         if (!types.includes(type)) {
           types.push(type)

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -95,7 +95,7 @@ const keys: Record<symbol | string, string> = {
   [Endpoint]: '[Endpoint]',
 }
 
-function stringifyRouteTree(tree: RouteTree, indent = 2): string {
+function stringifyRouteTree(tree: RouteTree, indent = 2, metadata = false): string {
   let properties = ''
   const entries = [
     ...Object.entries(tree),
@@ -105,7 +105,9 @@ function stringifyRouteTree(tree: RouteTree, indent = 2): string {
     if (!value) {
       continue
     }
-    const key = keys[_key] || JSON.stringify((_key as string).replace(/Type$/, ''))
+    // the `Type` suffix belongs to metadata fields (`responseType` -> `response`); a static
+    // segment that happens to end in `Type` keeps its name
+    const key = keys[_key] || JSON.stringify(metadata ? (_key as string).replace(/Type$/, '') : _key as string)
     if (_key === Endpoint) {
       properties += `${' '.repeat(indent)}${key}: ${stringifyEndpoints(value as Record<string, Record<string, string[]>>, indent)}\n`
     }
@@ -118,7 +120,7 @@ function stringifyRouteTree(tree: RouteTree, indent = 2): string {
       properties += `${' '.repeat(indent)}${key}: ${value}\n`
     }
     else {
-      const str = stringifyRouteTree(value as RouteTree, indent + 2)
+      const str = stringifyRouteTree(value as RouteTree, indent + 2, metadata)
       properties += `${' '.repeat(indent)}${key}: {\n${str}${' '.repeat(indent)}}\n`
     }
   }
@@ -135,7 +137,7 @@ function stringifyEndpoints(endpoints: Record<string, Record<string, string[]>>,
   const named = Object.keys(methods)
 
   const specific = named.length > 0
-    ? `{\n${stringifyRouteTree(methods as unknown as RouteTree, indent + 2)}${' '.repeat(indent)}}`
+    ? `{\n${stringifyRouteTree(methods as unknown as RouteTree, indent + 2, true)}${' '.repeat(indent)}}`
     : undefined
 
   if (!all) {
@@ -145,7 +147,7 @@ function stringifyEndpoints(endpoints: Record<string, Record<string, string[]>>,
   const covered = named.length > 0
     ? `Exclude<HTTPMethod, ${named.map(method => JSON.stringify(method)).join(' | ')}>`
     : 'HTTPMethod'
-  const record = `Record<${covered}, {\n${stringifyRouteTree(all as unknown as RouteTree, indent + 2)}${' '.repeat(indent)}}>`
+  const record = `Record<${covered}, {\n${stringifyRouteTree(all as unknown as RouteTree, indent + 2, true)}${' '.repeat(indent)}}>`
 
   return specific ? `${record} & ${specific}` : record
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -52,7 +52,18 @@ export function serializeRoutes(name: string, routes: Route[], options?: OutputO
 
     imports.add('Endpoint')
 
-    node[Endpoint] = Object.assign((node[Endpoint] as RouteTree) || {}, route.metadata)
+    // distinct patterns can share a node, such as two parameters distinguished only by a constraint
+    // the schema cannot express, so types are collected per field rather than overwritten
+    const endpoints = (node[Endpoint] = (node[Endpoint] as RouteTree) || {}) as Record<string, Record<string, string[]>>
+    for (const [method, metadata] of Object.entries(route.metadata || {})) {
+      const existing = endpoints[method] = endpoints[method] || {}
+      for (const [field, type] of Object.entries(metadata as Record<string, string>)) {
+        const types = existing[field] = existing[field] || []
+        if (!types.includes(type)) {
+          types.push(type)
+        }
+      }
+    }
   }
 
   // stringify resulting tree
@@ -81,7 +92,12 @@ function stringifyRouteTree(tree: RouteTree, indent = 2): string {
       continue
     }
     const key = keys[_key] || JSON.stringify((_key as string).replace(/Type$/, ''))
-    if (typeof value === 'string') {
+    if (Array.isArray(value)) {
+      // each type is parenthesised, as arbitrary type source may not be safe to union unbracketed
+      const type = value.length > 1 ? value.map(t => `(${t})`).join(' | ') : value[0]
+      properties += `${' '.repeat(indent)}${key}: ${type}\n`
+    }
+    else if (typeof value === 'string') {
       properties += `${' '.repeat(indent)}${key}: ${value}\n`
     }
     else {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -28,8 +28,13 @@ export interface Route {
    * with whichever tool owns them (see the readme).
    */
   segments: RouteSegment[]
+  /**
+   * Types for the endpoint, per method. `ALL` describes a handler registered for every method, as
+   * a route with no method is in nitro and h3, and is emitted as a `Record` over `HTTPMethod` so
+   * that it stays compact; a specific method takes precedence over it.
+   */
   metadata?: {
-    [key in HTTPMethod]?: Partial<Record<`${keyof EndpointMetadata}Type`, string>>
+    [key in HTTPMethod | 'ALL']?: Partial<Record<`${keyof EndpointMetadata}Type`, string>>
   }
   [key: string]: unknown
 }
@@ -50,12 +55,21 @@ export function serializeRoutes(name: string, routes: Route[], options?: OutputO
       node = node[key] as RouteTree
     }
 
+    // an endpoint with no methods would be offered as a valid path but resolve to `never`, so a
+    // route without metadata contributes its segments and nothing else
+    if (!route.metadata) {
+      continue
+    }
+
     imports.add('Endpoint')
+    if ('ALL' in route.metadata) {
+      imports.add('HTTPMethod')
+    }
 
     // distinct patterns can share a node, such as two parameters distinguished only by a constraint
     // the schema cannot express, so types are collected per field rather than overwritten
     const endpoints = (node[Endpoint] = (node[Endpoint] as RouteTree) || {}) as Record<string, Record<string, string[]>>
-    for (const [method, metadata] of Object.entries(route.metadata || {})) {
+    for (const [method, metadata] of Object.entries(route.metadata)) {
       const existing = endpoints[method] = endpoints[method] || {}
       for (const [field, type] of Object.entries(metadata as Record<string, string>)) {
         const types = existing[field] = existing[field] || []
@@ -92,7 +106,10 @@ function stringifyRouteTree(tree: RouteTree, indent = 2): string {
       continue
     }
     const key = keys[_key] || JSON.stringify((_key as string).replace(/Type$/, ''))
-    if (Array.isArray(value)) {
+    if (_key === Endpoint) {
+      properties += `${' '.repeat(indent)}${key}: ${stringifyEndpoints(value as Record<string, Record<string, string[]>>, indent)}\n`
+    }
+    else if (Array.isArray(value)) {
       // each type is parenthesised, as arbitrary type source may not be safe to union unbracketed
       const type = value.length > 1 ? value.map(t => `(${t})`).join(' | ') : value[0]
       properties += `${' '.repeat(indent)}${key}: ${type}\n`
@@ -107,6 +124,30 @@ function stringifyRouteTree(tree: RouteTree, indent = 2): string {
   }
 
   return properties
+}
+
+/**
+ * Stringifies the methods of one endpoint. An `ALL` entry becomes a `Record` over every method,
+ * with any specific method excluded from it and intersected on, so that the specific entry wins.
+ */
+function stringifyEndpoints(endpoints: Record<string, Record<string, string[]>>, indent: number): string {
+  const { ALL: all, ...methods } = endpoints
+  const named = Object.keys(methods)
+
+  const specific = named.length > 0
+    ? `{\n${stringifyRouteTree(methods as unknown as RouteTree, indent + 2)}${' '.repeat(indent)}}`
+    : undefined
+
+  if (!all) {
+    return specific || `{\n${' '.repeat(indent)}}`
+  }
+
+  const covered = named.length > 0
+    ? `Exclude<HTTPMethod, ${named.map(method => JSON.stringify(method)).join(' | ')}>`
+    : 'HTTPMethod'
+  const record = `Record<${covered}, {\n${stringifyRouteTree(all as unknown as RouteTree, indent + 2)}${' '.repeat(indent)}}>`
+
+  return specific ? `${record} & ${specific}` : record
 }
 
 function segmentKey(segment: RouteSegment): string | symbol {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -14,6 +14,12 @@ export interface EndpointMetadata {
   headers: Record<string, unknown>
   body: never | Record<string, unknown>
   response: unknown
+  /**
+   * The response where the request could have matched a static sibling of the parameter it was
+   * resolved through, because the segment was known only at runtime. Typically a union of this
+   * endpoint's response and those of the siblings; see the readme.
+   */
+  ambiguousResponse: unknown
   responseHeaders: Record<string, unknown>
 }
 

--- a/test/depth.test-d.ts
+++ b/test/depth.test-d.ts
@@ -55,6 +55,13 @@ describe('nested route resolution', () => {
     expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files/a'>>().toEqualTypeOf<9>()
   })
 
+  it('requires a wildcard to consume a non-empty segment', () => {
+    expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files/'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files//'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files///'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files//a'>>().toEqualTypeOf<9>()
+  })
+
   it('returns never for unmatched paths', () => {
     expectTypeOf<TypedFetchResponseBody<StaticDepth3, '/a/b'>>().toBeNever()
     expectTypeOf<TypedFetchResponseBody<StaticDepth3, '/a/b/d'>>().toBeNever()

--- a/test/depth.test-d.ts
+++ b/test/depth.test-d.ts
@@ -1,0 +1,138 @@
+import type { HTTPMethod } from '../src/http'
+import type { TypedFetchInput, TypedFetchMeta, TypedFetchRequestInit, TypedFetchResponseBody } from '../src/inference'
+import type { DynamicParam, Endpoint, WildcardParam } from '../src/tree'
+import type { GeneratedRoutes } from './fixture/generated'
+import { describe, expectTypeOf, it } from 'vitest'
+
+interface Depth1 {
+  '/posts': { [DynamicParam]: { [Endpoint]: { GET: { response: 1 } } } }
+}
+interface CombinedFirstSegment {
+  '/api/posts': { [DynamicParam]: { [Endpoint]: { GET: { response: 2 } } } }
+}
+interface StaticDepth2 {
+  '/a': { '/b': { [Endpoint]: { GET: { response: 3 } } } }
+}
+interface StaticDepth3 {
+  '/a': { '/b': { '/c': { [Endpoint]: { GET: { response: 4 } } } } }
+}
+interface StaticDepth4 {
+  '/a': { '/b': { '/c': { '/d': { [Endpoint]: { GET: { response: 5 } } } } } }
+}
+interface DynamicDepth3 {
+  '/api': { '/posts': { [DynamicParam]: { [Endpoint]: { GET: { response: 6 } } } } }
+}
+interface StaticAfterDynamic {
+  '/api/users': { [DynamicParam]: { '/posts': { [Endpoint]: { GET: { response: 7 } } } } }
+}
+interface TwoDynamic {
+  '/api/users': { [DynamicParam]: { '/posts': { [DynamicParam]: { [Endpoint]: { GET: { response: 8 } } } } } }
+}
+interface DeepWildcard {
+  '/api': { '/files': { [WildcardParam]: { [Endpoint]: { GET: { response: 9 } } } } }
+}
+
+describe('nested route resolution', () => {
+  it('resolves dynamic parameters at any depth', () => {
+    expectTypeOf<TypedFetchResponseBody<Depth1, '/posts/x'>>().toEqualTypeOf<1>()
+    expectTypeOf<TypedFetchResponseBody<CombinedFirstSegment, '/api/posts/x'>>().toEqualTypeOf<2>()
+    expectTypeOf<TypedFetchResponseBody<DynamicDepth3, '/api/posts/x'>>().toEqualTypeOf<6>()
+  })
+
+  it('resolves static segments at any depth', () => {
+    expectTypeOf<TypedFetchResponseBody<StaticDepth2, '/a/b'>>().toEqualTypeOf<3>()
+    expectTypeOf<TypedFetchResponseBody<StaticDepth3, '/a/b/c'>>().toEqualTypeOf<4>()
+    expectTypeOf<TypedFetchResponseBody<StaticDepth4, '/a/b/c/d'>>().toEqualTypeOf<5>()
+  })
+
+  it('resolves static segments following a dynamic parameter', () => {
+    expectTypeOf<TypedFetchResponseBody<StaticAfterDynamic, '/api/users/123/posts'>>().toEqualTypeOf<7>()
+    expectTypeOf<TypedFetchResponseBody<TwoDynamic, '/api/users/1/posts/2'>>().toEqualTypeOf<8>()
+  })
+
+  it('resolves wildcards at any depth', () => {
+    expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files/a/b'>>().toEqualTypeOf<9>()
+    expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files/a'>>().toEqualTypeOf<9>()
+  })
+
+  it('returns never for unmatched paths', () => {
+    expectTypeOf<TypedFetchResponseBody<StaticDepth3, '/a/b'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<StaticDepth3, '/a/b/d'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<StaticAfterDynamic, '/api/users/123/comments'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files/'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<Depth1, '/posts/'>>().toBeNever()
+  })
+
+  it('lists nested paths as valid input', () => {
+    expectTypeOf<'/a/b/c'>().toMatchTypeOf<TypedFetchInput<StaticDepth3>>()
+    expectTypeOf<'/api/users/123/posts'>().toMatchTypeOf<TypedFetchInput<StaticAfterDynamic>>()
+    expectTypeOf<'/api/users/1/posts/2'>().toMatchTypeOf<TypedFetchInput<TwoDynamic>>()
+  })
+
+  it('types request init for nested paths', () => {
+    expectTypeOf<TypedFetchMeta<StaticDepth3, '/a/b/c'>['method']>().toEqualTypeOf<'GET'>()
+    expectTypeOf<{ method: 'GET' }>().toMatchTypeOf<TypedFetchRequestInit<StaticDepth3, '/a/b/c'>>()
+  })
+})
+
+describe('serialized schema', () => {
+  it('is resolvable by the inference types', () => {
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/health'>>().toEqualTypeOf<{ status: 'ok' }>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/users'>>().toEqualTypeOf<{ id: number }[]>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/users', 'POST'>>().toEqualTypeOf<{ id: number }>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/users/123'>>().toEqualTypeOf<{ id: number, name: string }>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/users/123/posts'>>().toEqualTypeOf<{ title: string }[]>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/comments/1'>>().toEqualTypeOf<{ body: string }>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/files/a/b.txt'>>().toEqualTypeOf<Blob>()
+    expectTypeOf<TypedFetchMeta<GeneratedRoutes, '/api/users', 'POST'>['body']>().toEqualTypeOf<{ name: string }>()
+  })
+})
+
+interface ReadmeSchema {
+  '/api': {
+    '/health': {
+      [Endpoint]: { GET: { response: { status: 'ok' | 'error' } } }
+    }
+    '/users': {
+      [Endpoint]: {
+        GET: { response: { id: number }[] }
+        POST: { body: { name: string }, response: { id: number } }
+      }
+      [DynamicParam]: {
+        [Endpoint]: { GET: { response: { id: number } } }
+        '/posts': {
+          [Endpoint]: { GET: { response: { title: string }[] } }
+          [DynamicParam]: {
+            [Endpoint]: { GET: { response: { title: string } } }
+          }
+        }
+      }
+    }
+  }
+}
+
+describe('documented mixed static and dynamic schema', () => {
+  it('resolves every documented path', () => {
+    expectTypeOf<TypedFetchResponseBody<ReadmeSchema, '/api/health'>>().toEqualTypeOf<{ status: 'ok' | 'error' }>()
+    expectTypeOf<TypedFetchResponseBody<ReadmeSchema, '/api/users'>>().toEqualTypeOf<{ id: number }[]>()
+    expectTypeOf<TypedFetchResponseBody<ReadmeSchema, '/api/users/123'>>().toEqualTypeOf<{ id: number }>()
+    expectTypeOf<TypedFetchResponseBody<ReadmeSchema, '/api/users/123/posts'>>().toEqualTypeOf<{ title: string }[]>()
+    expectTypeOf<TypedFetchResponseBody<ReadmeSchema, '/api/users/123/posts/456'>>().toEqualTypeOf<{ title: string }>()
+    expectTypeOf<TypedFetchResponseBody<ReadmeSchema, '/api/users', 'POST'>>().toEqualTypeOf<{ id: number }>()
+  })
+})
+
+interface AllMethods {
+  '/api': {
+    '/hello': {
+      [Endpoint]: Record<HTTPMethod, { response: { hello: string } }>
+    }
+  }
+}
+
+describe('method-agnostic handlers', () => {
+  it('resolves for every method', () => {
+    expectTypeOf<TypedFetchResponseBody<AllMethods, '/api/hello'>>().toEqualTypeOf<{ hello: string }>()
+    expectTypeOf<TypedFetchResponseBody<AllMethods, '/api/hello', 'PATCH'>>().toEqualTypeOf<{ hello: string }>()
+  })
+})

--- a/test/depth.test-d.ts
+++ b/test/depth.test-d.ts
@@ -62,6 +62,18 @@ describe('nested route resolution', () => {
     expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files//a'>>().toEqualTypeOf<9>()
   })
 
+  it('returns unknown for a route registered without a return type', () => {
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/proxy'>>().toBeUnknown()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/proxy', 'DELETE'>>().toBeUnknown()
+    expectTypeOf<'/api/proxy'>().toMatchTypeOf<TypedFetchInput<GeneratedRoutes>>()
+
+    // a declared response is unaffected, and neither an unregistered method nor an unmatched path
+    // becomes callable
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/health'>>().toEqualTypeOf<{ status: 'ok' }>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/health', 'PUT'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/nope'>>().toBeNever()
+  })
+
   it('returns never for unmatched paths', () => {
     expectTypeOf<TypedFetchResponseBody<StaticDepth3, '/a/b'>>().toBeNever()
     expectTypeOf<TypedFetchResponseBody<StaticDepth3, '/a/b/d'>>().toBeNever()

--- a/test/depth.test-d.ts
+++ b/test/depth.test-d.ts
@@ -1,5 +1,5 @@
 import type { HTTPMethod } from '../src/http'
-import type { TypedFetchInput, TypedFetchMeta, TypedFetchRequestInit, TypedFetchResponseBody } from '../src/inference'
+import type { TypedFetchInput, TypedFetchMeta, TypedFetchRequestInit, TypedFetchResolvedMeta, TypedFetchResponseBody } from '../src/inference'
 import type { DynamicParam, Endpoint, WildcardParam } from '../src/tree'
 import type { GeneratedRoutes } from './fixture/generated'
 import { describe, expectTypeOf, it } from 'vitest'
@@ -72,6 +72,18 @@ describe('nested route resolution', () => {
   it('types request init for nested paths', () => {
     expectTypeOf<TypedFetchMeta<StaticDepth3, '/a/b/c'>['method']>().toEqualTypeOf<'GET'>()
     expectTypeOf<{ method: 'GET' }>().toMatchTypeOf<TypedFetchRequestInit<StaticDepth3, '/a/b/c'>>()
+  })
+
+  it('types request init for paths reached through a parameter', () => {
+    expectTypeOf<TypedFetchResolvedMeta<StaticAfterDynamic, '/api/users/123/posts'>['method']>().toEqualTypeOf<'GET'>()
+    expectTypeOf<TypedFetchResolvedMeta<DeepWildcard, '/api/files/a/b'>['method']>().toEqualTypeOf<'GET'>()
+
+    // a parameterised path is only reached by the dynamic pass, so an exact-only lookup would leave
+    // every property of the init `never` and make the options object impossible to satisfy
+    expectTypeOf<TypedFetchRequestInit<StaticAfterDynamic, '/api/users/123/posts'>>().not.toBeNever()
+    expectTypeOf<{ method: 'GET' }>().toMatchTypeOf<TypedFetchRequestInit<StaticAfterDynamic, '/api/users/123/posts'>>()
+    expectTypeOf<{ method: 'GET' }>().toMatchTypeOf<TypedFetchRequestInit<DeepWildcard, '/api/files/a/b'>>()
+    expectTypeOf<TypedFetchRequestInit<GeneratedRoutes, '/api/users/123'>['body']>().not.toBeNever()
   })
 })
 

--- a/test/depth.test-d.ts
+++ b/test/depth.test-d.ts
@@ -60,7 +60,9 @@ describe('nested route resolution', () => {
     expectTypeOf<TypedFetchResponseBody<StaticDepth3, '/a/b/d'>>().toBeNever()
     expectTypeOf<TypedFetchResponseBody<StaticAfterDynamic, '/api/users/123/comments'>>().toBeNever()
     expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/files/'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<DeepWildcard, '/api/filesystem'>>().toBeNever()
     expectTypeOf<TypedFetchResponseBody<Depth1, '/posts/'>>().toBeNever()
+    expectTypeOf<TypedFetchResponseBody<Depth1, '/postscript'>>().toBeNever()
   })
 
   it('lists nested paths as valid input', () => {

--- a/test/depth.test-d.ts
+++ b/test/depth.test-d.ts
@@ -147,4 +147,18 @@ describe('method-agnostic handlers', () => {
     expectTypeOf<TypedFetchResponseBody<AllMethods, '/api/hello'>>().toEqualTypeOf<{ hello: string }>()
     expectTypeOf<TypedFetchResponseBody<AllMethods, '/api/hello', 'PATCH'>>().toEqualTypeOf<{ hello: string }>()
   })
+
+  it('resolves the serialized `ALL` form for every method', () => {
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/ping'>>().toEqualTypeOf<'pong'>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/ping', 'DELETE'>>().toEqualTypeOf<'pong'>()
+    expectTypeOf<'/api/ping'>().toMatchTypeOf<TypedFetchInput<GeneratedRoutes>>()
+  })
+
+  it('prefers a specific method over the `ALL` form', () => {
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/search', 'POST'>>().toEqualTypeOf<{ results: string[], total: number }>()
+    expectTypeOf<TypedFetchMeta<GeneratedRoutes, '/api/search', 'POST'>['body']>().toEqualTypeOf<{ query: string }>()
+
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/search', 'GET'>>().toEqualTypeOf<{ results: string[] }>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/search', 'PATCH'>>().toEqualTypeOf<{ results: string[] }>()
+  })
 })

--- a/test/depth.test-d.ts
+++ b/test/depth.test-d.ts
@@ -164,3 +164,60 @@ describe('method-agnostic handlers', () => {
     expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/search', 'PATCH'>>().toEqualTypeOf<{ results: string[] }>()
   })
 })
+
+interface Ambiguous {
+  '/api/posts': {
+    '/static': { [Endpoint]: { GET: { response: 'static' } } }
+    '/other': { [Endpoint]: { GET: { response: 'other' } } }
+    [DynamicParam]: { [Endpoint]: { GET: { response: 'param', ambiguousResponse: 'param' | 'static' | 'other' } } }
+  }
+}
+
+interface AmbiguousAfterParam {
+  '/api/users': {
+    '/me': { '/posts': { [Endpoint]: { GET: { response: 'mine' } } } }
+    [DynamicParam]: { '/posts': { [Endpoint]: { GET: { response: 'posts', ambiguousResponse: 'posts' | 'mine' } } } }
+  }
+}
+
+interface AmbiguousWildcard {
+  '/api/files': {
+    [WildcardParam]: { [Endpoint]: { GET: { response: 'wild', ambiguousResponse: 'unused' } } }
+  }
+}
+
+describe('requests whose segments are only known at runtime', () => {
+  it('resolves the declared alternative for a non-literal segment', () => {
+    expectTypeOf<TypedFetchResponseBody<Ambiguous, `/api/posts/${string}`>>().toEqualTypeOf<'param' | 'static' | 'other'>()
+    expectTypeOf<TypedFetchResponseBody<AmbiguousAfterParam, `/api/users/${string}/posts`>>().toEqualTypeOf<'posts' | 'mine'>()
+  })
+
+  it('resolves a literal segment exactly', () => {
+    expectTypeOf<TypedFetchResponseBody<Ambiguous, '/api/posts/123'>>().toEqualTypeOf<'param'>()
+    expectTypeOf<TypedFetchResponseBody<Ambiguous, '/api/posts/static'>>().toEqualTypeOf<'static'>()
+    expectTypeOf<TypedFetchResponseBody<AmbiguousAfterParam, '/api/users/123/posts'>>().toEqualTypeOf<'posts'>()
+    expectTypeOf<TypedFetchResponseBody<AmbiguousAfterParam, '/api/users/me/posts'>>().toEqualTypeOf<'mine'>()
+  })
+
+  it('leaves a schema without an alternative untouched', () => {
+    expectTypeOf<TypedFetchResponseBody<StaticAfterDynamic, `/api/users/${string}/posts`>>().toEqualTypeOf<7>()
+    expectTypeOf<TypedFetchResponseBody<TwoDynamic, `/api/users/${string}/posts/${string}`>>().toEqualTypeOf<8>()
+  })
+
+  it('does not apply the alternative to a wildcard', () => {
+    expectTypeOf<TypedFetchResponseBody<AmbiguousWildcard, '/api/files/a/b'>>().toEqualTypeOf<'wild'>()
+    expectTypeOf<TypedFetchResponseBody<AmbiguousWildcard, `/api/files/${string}`>>().toEqualTypeOf<'wild'>()
+  })
+
+  it('keeps the alternative out of the metadata and the request init', () => {
+    expectTypeOf<'ambiguousResponse' extends keyof TypedFetchMeta<Ambiguous, `/api/posts/${string}`, 'GET', 'dynamic'> ? true : false>().toEqualTypeOf<false>()
+    expectTypeOf<TypedFetchMeta<Ambiguous, `/api/posts/${string}`, 'GET', 'dynamic'>['method']>().toEqualTypeOf<'GET'>()
+    expectTypeOf<{ method: 'GET' }>().toMatchTypeOf<TypedFetchRequestInit<Ambiguous, `/api/posts/${string}`>>()
+  })
+
+  it('resolves the serialized form', () => {
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/comments/1'>>().toEqualTypeOf<{ body: string }>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, '/api/comments/latest'>>().toEqualTypeOf<{ latest: true }>()
+    expectTypeOf<TypedFetchResponseBody<GeneratedRoutes, `/api/comments/${string}`>>().toEqualTypeOf<{ body: string } | { latest: true }>()
+  })
+})

--- a/test/env.d.ts
+++ b/test/env.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const source: string
+  export default source
+}

--- a/test/fixture/generated.ts
+++ b/test/fixture/generated.ts
@@ -1,0 +1,56 @@
+import type { DynamicParam, Endpoint, WildcardParam } from 'fetchdts'
+
+export interface GeneratedRoutes {
+  "/api": {
+    "/health": {
+      [Endpoint]: {
+        "GET": {
+          "response": { status: 'ok' }
+        }
+      }
+    }
+    "/users": {
+      [DynamicParam]: {
+        "/posts": {
+          [Endpoint]: {
+            "GET": {
+              "response": { title: string }[]
+            }
+          }
+        }
+        [Endpoint]: {
+          "GET": {
+            "response": { id: number, name: string }
+          }
+        }
+      }
+      [Endpoint]: {
+        "GET": {
+          "response": { id: number }[]
+        }
+        "POST": {
+          "body": { name: string }
+          "response": { id: number }
+        }
+      }
+    }
+    "/comments": {
+      [DynamicParam]: {
+        [Endpoint]: {
+          "GET": {
+            "response": { body: string }
+          }
+        }
+      }
+    }
+    "/files": {
+      [WildcardParam]: {
+        [Endpoint]: {
+          "GET": {
+            "response": Blob
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixture/generated.ts
+++ b/test/fixture/generated.ts
@@ -66,6 +66,10 @@ export interface GeneratedRoutes {
         }
       }
     }
+    "/proxy": {
+      [Endpoint]: Record<HTTPMethod, {
+      }>
+    }
     "/files": {
       [WildcardParam]: {
         [Endpoint]: {

--- a/test/fixture/generated.ts
+++ b/test/fixture/generated.ts
@@ -35,10 +35,18 @@ export interface GeneratedRoutes {
       }
     }
     "/comments": {
+      "/latest": {
+        [Endpoint]: {
+          "GET": {
+            "response": { latest: true }
+          }
+        }
+      }
       [DynamicParam]: {
         [Endpoint]: {
           "GET": {
             "response": { body: string }
+            "ambiguousResponse": { body: string } | { latest: true }
           }
         }
       }

--- a/test/fixture/generated.ts
+++ b/test/fixture/generated.ts
@@ -1,4 +1,4 @@
-import type { DynamicParam, Endpoint, WildcardParam } from 'fetchdts'
+import type { DynamicParam, Endpoint, HTTPMethod, WildcardParam } from 'fetchdts'
 
 export interface GeneratedRoutes {
   "/api": {
@@ -40,6 +40,21 @@ export interface GeneratedRoutes {
           "GET": {
             "response": { body: string }
           }
+        }
+      }
+    }
+    "/ping": {
+      [Endpoint]: Record<HTTPMethod, {
+        "response": 'pong'
+      }>
+    }
+    "/search": {
+      [Endpoint]: Record<Exclude<HTTPMethod, "POST">, {
+        "response": { results: string[] }
+      }> & {
+        "POST": {
+          "body": { query: string }
+          "response": { results: string[], total: number }
         }
       }
     }

--- a/test/fixture/routes.ts
+++ b/test/fixture/routes.ts
@@ -35,6 +35,20 @@ export const routes: Route[] = [
     },
   },
   {
+    // a handler registered for every method, as a route with no method is in nitro
+    segments: ['/api', '/ping'],
+    metadata: {
+      ALL: { responseType: '\'pong\'' },
+    },
+  },
+  {
+    segments: ['/api', '/search'],
+    metadata: {
+      ALL: { responseType: '{ results: string[] }' },
+      POST: { bodyType: '{ query: string }', responseType: '{ results: string[], total: number }' },
+    },
+  },
+  {
     segments: ['/api', '/files', WildcardParam],
     metadata: {
       GET: { responseType: 'Blob' },

--- a/test/fixture/routes.ts
+++ b/test/fixture/routes.ts
@@ -29,9 +29,19 @@ export const routes: Route[] = [
     },
   },
   {
+    segments: ['/api', '/comments', '/latest'],
+    metadata: {
+      GET: { responseType: '{ latest: true }' },
+    },
+  },
+  {
+    // a request built from a runtime value could match `/latest`, so the caller precomputes the union
     segments: ['/api', '/comments', DynamicParam],
     metadata: {
-      GET: { responseType: '{ body: string }' },
+      GET: {
+        responseType: '{ body: string }',
+        ambiguousResponseType: '{ body: string } | { latest: true }',
+      },
     },
   },
   {

--- a/test/fixture/routes.ts
+++ b/test/fixture/routes.ts
@@ -1,0 +1,43 @@
+import type { Route } from '../../src/serialize'
+import { DynamicParam, WildcardParam } from '../../src/tree'
+
+export const routes: Route[] = [
+  {
+    segments: ['/api', '/health'],
+    metadata: {
+      GET: { responseType: '{ status: \'ok\' }' },
+    },
+  },
+  {
+    segments: ['/api', '/users'],
+    metadata: {
+      GET: { responseType: '{ id: number }[]' },
+      POST: { bodyType: '{ name: string }', responseType: '{ id: number }' },
+    },
+  },
+  {
+    segments: ['/api', '/users', DynamicParam],
+    metadata: {
+      GET: { responseType: '{ id: number, name: string }' },
+    },
+  },
+  {
+    // the plain object form, as it arrives from a tool that cannot pass symbols
+    segments: [{ type: 'static', value: 'api' }, { type: 'static', value: 'users' }, { type: 'dynamic' }, { type: 'static', value: 'posts' }],
+    metadata: {
+      GET: { responseType: '{ title: string }[]' },
+    },
+  },
+  {
+    segments: ['/api', '/comments', DynamicParam],
+    metadata: {
+      GET: { responseType: '{ body: string }' },
+    },
+  },
+  {
+    segments: ['/api', '/files', WildcardParam],
+    metadata: {
+      GET: { responseType: 'Blob' },
+    },
+  },
+]

--- a/test/fixture/routes.ts
+++ b/test/fixture/routes.ts
@@ -59,6 +59,13 @@ export const routes: Route[] = [
     },
   },
   {
+    // a route whose return type could not be resolved: callable, but nothing is known about it
+    segments: ['/api', '/proxy'],
+    metadata: {
+      ALL: {},
+    },
+  },
+  {
     segments: ['/api', '/files', WildcardParam],
     metadata: {
       GET: { responseType: 'Blob' },

--- a/test/schema.test-d.ts
+++ b/test/schema.test-d.ts
@@ -149,19 +149,25 @@ describe('fetchdts', () => {
   })
 })
 
-type CustomTypedFetchRequestInit<Schema, T extends TypedFetchInput<Schema>> = TypedFetchRequestInit<Schema, T> & RespectOptionality<TypedFetchResolvedMeta<Schema, T>, 'query', Record<string, unknown>>
+// the init type sits in parameter position rather than as a generic constraint, so that it is
+// computed for the path being requested rather than for every path in the schema
+type CustomTypedFetchRequestInit<Schema, T extends TypedFetchInput<Schema>>
+  = TypedFetchRequestInit<Schema, T>
+    & RespectOptionality<TypedFetchResolvedMeta<Schema, T>, 'query', Record<string, unknown>>
+    // endpoints declare the headers they require, without ruling out any others
+    & { headers?: Record<string, string> }
 
-function infer<T extends TypedFetchInput<ExampleSchema>, Init extends CustomTypedFetchRequestInit<ExampleSchema, T>>(_input: T, _init: Init): TypedFetchResponseBody<ExampleSchema, Trimmed<T>, Init['method'] extends HTTPMethod ? Init['method'] : 'GET'>
+function infer<T extends TypedFetchInput<ExampleSchema>, M extends HTTPMethod>(_input: T, _init: CustomTypedFetchRequestInit<ExampleSchema, T> & { method: M }): TypedFetchResponseBody<ExampleSchema, Trimmed<T>, M>
 
-function infer<T extends TypedFetchInput<ExampleSchema, 'GET'>, Init extends CustomTypedFetchRequestInit<ExampleSchema, T>>(_input: T, _init?: Init): TypedFetchResponseBody<ExampleSchema, Trimmed<T>, 'GET'>
+function infer<T extends TypedFetchInput<ExampleSchema, 'GET'>>(_input: T, _init?: CustomTypedFetchRequestInit<ExampleSchema, T>): TypedFetchResponseBody<ExampleSchema, Trimmed<T>, 'GET'>
 
 function infer(_input: any, _init?: any) {
   return {} as any
 }
 
-function inferResponse<T extends TypedFetchInput<ExampleSchema>, Init extends CustomTypedFetchRequestInit<ExampleSchema, T>>(_input: T, _init: Init): TypedResponse<TypedFetchResponseBody<ExampleSchema, Trimmed<T>, Init['method'] extends HTTPMethod ? Init['method'] : 'GET'>, TypedFetchResponseHeaders<ExampleSchema, Trimmed<T>, Init['method'] extends HTTPMethod ? Init['method'] : 'GET'>>
+function inferResponse<T extends TypedFetchInput<ExampleSchema>, M extends HTTPMethod>(_input: T, _init: CustomTypedFetchRequestInit<ExampleSchema, T> & { method: M }): TypedResponse<TypedFetchResponseBody<ExampleSchema, Trimmed<T>, M>, TypedFetchResponseHeaders<ExampleSchema, Trimmed<T>, M>>
 
-function inferResponse<T extends TypedFetchInput<ExampleSchema, 'GET'>, Init extends CustomTypedFetchRequestInit<ExampleSchema, T>>(_input: T, _init?: Init): TypedResponse<TypedFetchResponseBody<ExampleSchema, Trimmed<T>, 'GET'>, TypedFetchResponseHeaders<ExampleSchema, Trimmed<T>, 'GET'>>
+function inferResponse<T extends TypedFetchInput<ExampleSchema, 'GET'>>(_input: T, _init?: CustomTypedFetchRequestInit<ExampleSchema, T>): TypedResponse<TypedFetchResponseBody<ExampleSchema, Trimmed<T>, 'GET'>, TypedFetchResponseHeaders<ExampleSchema, Trimmed<T>, 'GET'>>
 
 function inferResponse(_input: any, _init?: any) {
   return {} as any

--- a/test/schema.test-d.ts
+++ b/test/schema.test-d.ts
@@ -1,6 +1,6 @@
 import type { TypedResponse } from '../src/fetch'
 import type { HTTPMethod } from '../src/http'
-import type { TypedFetchInput, TypedFetchMeta, TypedFetchRequestInit, TypedFetchResponseBody, TypedFetchResponseHeaders } from '../src/inference'
+import type { TypedFetchInput, TypedFetchRequestInit, TypedFetchResolvedMeta, TypedFetchResponseBody, TypedFetchResponseHeaders } from '../src/inference'
 import type { RespectOptionality, Trimmed } from '../src/utils'
 
 import type { ExampleSchema } from './fixture/schema'
@@ -40,6 +40,15 @@ describe('fetchdts', () => {
     infer('/methods/post')
 
     expectTypeOf(infer('/methods/post', { method: 'POST' })).toEqualTypeOf<{ method: 'POST' }>()
+  })
+
+  it('should accept options for paths reached through a parameter', () => {
+    expectTypeOf(infer('/api/dynamic', { method: 'POST' })).toEqualTypeOf<{ type: 'dynamic', method: 'POST' }>()
+    // the wildcard endpoint declares a body, which is required as it would be for a static path
+    expectTypeOf(infer('https://jsonplaceholder.typicode.com/anything', { method: 'GET', body: { id: true } })).toEqualTypeOf<string>()
+
+    // @ts-expect-error missing body
+    infer('https://jsonplaceholder.typicode.com/anything', { method: 'GET' })
   })
 
   it('should support parameters', () => {
@@ -140,7 +149,7 @@ describe('fetchdts', () => {
   })
 })
 
-type CustomTypedFetchRequestInit<Schema, T extends TypedFetchInput<Schema>> = TypedFetchRequestInit<Schema, T> & RespectOptionality<TypedFetchMeta<Schema, T>, 'query', Record<string, unknown>>
+type CustomTypedFetchRequestInit<Schema, T extends TypedFetchInput<Schema>> = TypedFetchRequestInit<Schema, T> & RespectOptionality<TypedFetchResolvedMeta<Schema, T>, 'query', Record<string, unknown>>
 
 function infer<T extends TypedFetchInput<ExampleSchema>, Init extends CustomTypedFetchRequestInit<ExampleSchema, T>>(_input: T, _init: Init): TypedFetchResponseBody<ExampleSchema, Trimmed<T>, Init['method'] extends HTTPMethod ? Init['method'] : 'GET'>
 

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -117,4 +117,31 @@ describe('serialize', () => {
       }"
     `)
   })
+
+  it('should union the types of routes that resolve to the same endpoint', () => {
+    const tree = serializeRoutes('InternalRoutes', [
+      { segments: ['/users', DynamicParam], metadata: { GET: { responseType: 'User' } } },
+      { segments: ['/users', DynamicParam], metadata: { GET: { responseType: '(Post | Draft)[]' } } },
+      { segments: ['/users', DynamicParam], metadata: { GET: { responseType: 'User' }, POST: { responseType: 'Created' } } },
+    ])
+
+    expect(tree).toMatchInlineSnapshot(`
+      "import type { DynamicParam, Endpoint } from 'fetchdts'
+
+      interface InternalRoutes {
+        "/users": {
+          [DynamicParam]: {
+            [Endpoint]: {
+              "GET": {
+                "response": (User) | ((Post | Draft)[])
+              }
+              "POST": {
+                "response": Created
+              }
+            }
+          }
+        }
+      }"
+    `)
+  })
 })

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { serializeRoutes } from '../src'
+import { DynamicParam, serializeRoutes } from '../src'
+import generated from './fixture/generated.ts?raw'
+import { routes } from './fixture/routes'
 
 describe('serialize', () => {
   it('should serialize a route tree', () => {
     const tree = serializeRoutes('InternalRoutes', [
       {
-        path: '/',
+        segments: ['/'],
         metadata: {
           GET: {
             responseType: '{ type: \'headers\', method: \'POST\' }',
@@ -14,8 +16,7 @@ describe('serialize', () => {
         },
       },
       {
-        path: '/bob',
-        type: 'dynamic',
+        segments: ['/bob', DynamicParam],
         metadata: {
           POST: {
             responseType: '{ type: \'headers\', method: \'POST\' }',
@@ -26,20 +27,90 @@ describe('serialize', () => {
     ])
 
     expect(tree).toMatchInlineSnapshot(`
-      "import { DynamicParam } from 'fetchdts'
+      "import type { DynamicParam, Endpoint } from 'fetchdts'
 
       interface InternalRoutes {
         "/": {
-          "GET": {
-            "response": { type: 'headers', method: 'POST' }
-            "headers": { authorization: 'string' }
+          [Endpoint]: {
+            "GET": {
+              "response": { type: 'headers', method: 'POST' }
+              "headers": { authorization: 'string' }
+            }
           }
         }
         "/bob": {
           [DynamicParam]: {
-            "POST": {
-              "response": { type: 'headers', method: 'POST' }
-              "headers": { authorization: 'string' }
+            [Endpoint]: {
+              "POST": {
+                "response": { type: 'headers', method: 'POST' }
+                "headers": { authorization: 'string' }
+              }
+            }
+          }
+        }
+      }"
+    `)
+  })
+
+  it('should emit a schema the inference types can resolve', () => {
+    expect(`${serializeRoutes('GeneratedRoutes', routes, { export: true })}\n`).toBe(generated)
+  })
+
+  it('should accept both segment spellings and normalise static segments', () => {
+    const tree = serializeRoutes('InternalRoutes', [
+      {
+        segments: ['/users', DynamicParam, '/posts'],
+        metadata: { GET: { responseType: 'Post[]' } },
+      },
+      {
+        segments: [{ type: 'static', value: 'users' }, { type: 'dynamic' }],
+        metadata: { GET: { responseType: 'User' } },
+      },
+      {
+        segments: ['/files', { type: 'wildcard' }],
+        metadata: { GET: { responseType: 'Blob' } },
+      },
+      {
+        segments: ['https://api.example.com', '/status'],
+        metadata: { GET: { responseType: 'Status' } },
+      },
+    ])
+
+    expect(tree).toMatchInlineSnapshot(`
+      "import type { DynamicParam, Endpoint, WildcardParam } from 'fetchdts'
+
+      interface InternalRoutes {
+        "/users": {
+          [DynamicParam]: {
+            "/posts": {
+              [Endpoint]: {
+                "GET": {
+                  "response": Post[]
+                }
+              }
+            }
+            [Endpoint]: {
+              "GET": {
+                "response": User
+              }
+            }
+          }
+        }
+        "/files": {
+          [WildcardParam]: {
+            [Endpoint]: {
+              "GET": {
+                "response": Blob
+              }
+            }
+          }
+        }
+        "https://api.example.com": {
+          "/status": {
+            [Endpoint]: {
+              "GET": {
+                "response": Status
+              }
             }
           }
         }

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -145,6 +145,28 @@ describe('serialize', () => {
     `)
   })
 
+  it('should keep a static segment ending in `Type` intact', () => {
+    const tree = serializeRoutes('InternalRoutes', [
+      { segments: ['/api', '/contentType'], metadata: { GET: { responseType: 'string' } } },
+    ])
+
+    expect(tree).toMatchInlineSnapshot(`
+      "import type { Endpoint } from 'fetchdts'
+
+      interface InternalRoutes {
+        "/api": {
+          "/contentType": {
+            [Endpoint]: {
+              "GET": {
+                "response": string
+              }
+            }
+          }
+        }
+      }"
+    `)
+  })
+
   it('should not emit an endpoint for a route without metadata', () => {
     const tree = serializeRoutes('InternalRoutes', [
       { segments: ['/api', '/health'] },

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -144,4 +144,29 @@ describe('serialize', () => {
       }"
     `)
   })
+
+  it('should not emit an endpoint for a route without metadata', () => {
+    const tree = serializeRoutes('InternalRoutes', [
+      { segments: ['/api', '/health'] },
+      { segments: ['/api', '/users'], metadata: { GET: { responseType: 'User[]' } } },
+    ])
+
+    expect(tree).toMatchInlineSnapshot(`
+      "import type { Endpoint } from 'fetchdts'
+
+      interface InternalRoutes {
+        "/api": {
+          "/health": {
+          }
+          "/users": {
+            [Endpoint]: {
+              "GET": {
+                "response": User[]
+              }
+            }
+          }
+        }
+      }"
+    `)
+  })
 })

--- a/test/serialize.test.ts
+++ b/test/serialize.test.ts
@@ -191,4 +191,32 @@ describe('serialize', () => {
       }"
     `)
   })
+
+  it('should not emit an endpoint for a route with no method metadata', () => {
+    const tree = serializeRoutes('InternalRoutes', [
+      { segments: ['/api', '/empty'], metadata: {} },
+      { segments: ['/api', '/undefined'], metadata: { GET: undefined } },
+      { segments: ['/api', '/partial'], metadata: { GET: { responseType: 'Ok' }, POST: undefined } },
+    ])
+
+    expect(tree).toMatchInlineSnapshot(`
+      "import type { Endpoint } from 'fetchdts'
+
+      interface InternalRoutes {
+        "/api": {
+          "/empty": {
+          }
+          "/undefined": {
+          }
+          "/partial": {
+            [Endpoint]: {
+              "GET": {
+                "response": Ok
+              }
+            }
+          }
+        }
+      }"
+    `)
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,11 @@
     "moduleDetection": "force",
     "module": "preserve",
     "moduleResolution": "bundler",
+    "paths": {
+      "fetchdts": [
+        "./src/index.ts"
+      ]
+    },
     "resolveJsonModule": true,
     "strict": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
I've been wiring `fetchdts` up to nuxt's typed `$fetch` (nuxt/nuxt#35769), so this is a bundle of fixes and performance improvements

## 🪲 resolution stops working below depth 2

anything nested more than one level under a top-level key currently resolves to `never`:

```ts
interface Schema {
  '/a': { '/b': { '/c': { [Endpoint]: { GET: { response: 'c' } } } } }
}

type R = TypedFetchResponseBody<Schema, '/a/b/c'> // never
```

this is because the `StaticParam` branch of `TypedFetchMeta` required the remainder of the path to be a *direct key* of the next level. that also meant a static segment *after* a dynamic one is unrepresentable, so `/api/users/:id/posts` coudl never be typed. a parameter is only considered where the static subtree at that level has nothing to offer, so static still wins over dynamic

`TypedFetchRequestInit` resolves the same way now, through a new `TypedFetchResolvedMeta`. (it used to do a static-only lookup.)

it's also more performant, because a walk only touches the matching subtree:

| routes | before | after |
| --- | --- | --- |
| 150 | 327,663 instantiations | 40,171 |
| 300 | 336,263 | 62,283 |
| 600 | 353,463 | 106,459 |

(60 call sites, depth 2, since deeper schemas resolve to `never` on `main` and so aren't comparable)

## 🐛 `serializeRoutes` output wasn't consumable

previously we never emitted `[Endpoint]`, so our own snapshot shape fed back through the library gave `never`:

```ts
interface NoEndpoint { '/api/hello': { GET: { response: string } } }
type R = TypedFetchResponseBody<NoEndpoint, '/api/hello'> // never
```

we now wrap metadata in `[Endpoint]`, imports the symbol alongside the others, and emits `import type` rather than a value import ...

metadata is also collected per field, since two routes can resolve to the same endpoint, in which case they are now unioned.

## ✨ `ALL` for handlers registered on every method

a handler with no method is valid for every verb, so `metadata` now takes an `ALL` entry, which the emitter expands into a `Record`. a specific method is excluded from it and intersected on, so it takes precedence:

```ts
metadata: { ALL: { responseType: 'User' }, POST: { responseType: 'Created' } }
// [Endpoint]: Record<Exclude<HTTPMethod, "POST">, { "response": User }> & { "POST": { "response": Created } }
```

on a route set that's two thirds method-less, that's a 5.7x smaller generated file + about half the types (no change in instantiations).

## 🎲 responses for requests built from runtime values

`$fetch('/api/posts/`${id`)` matches the dynamic parameter, but `id` could be `'static'` at runtime and hit a static sibling instead. an endpoint can now declare what to resolve to in that case:

```ts
[DynamicParam]: { [Endpoint]: { GET: { response: Post, ambiguousResponse: Post | Static } } }
```

| request | resolves to |
| --- | --- |
| `` `/api/posts/${string}` `` | `Post \| Static` |
| `/api/posts/123` | `Post` |
| `/api/posts/static` | `Static` |

the union isn't computed for you: which siblings a request could reach is a property of the route set, so whoever generates the schema knows it, and doing it once at generation time is ~20x cheaper than deriving it at every call site. an endpoint that declares no `ambiguousResponse` behaves exactly as before

## 🚨 breaking: routes are described as segments

`Route.path` is gone, along with `Route.type`. a route is now a list of segments, and `fetchdts` doesn't parse route patterns at all:

```diff
-serializeRoutes('APISchema', [
-  { path: '/users', metadata: { GET: { responseType: 'User[]' } } },
-  { path: '/users', type: 'dynamic', metadata: { GET: { responseType: 'User' } } },
-])
+serializeRoutes('APISchema', [
+  { segments: ['/users'], metadata: { GET: { responseType: 'User[]' } } },
+  { segments: ['/users', DynamicParam], metadata: { GET: { responseType: 'User' } } },
+])
```

if your patterns are [rou3](https://github.com/h3js/rou3) patterns, you can use `routeNodeKeys`. for filesystem routes, [`unrouting`](https://github.com/unjs/unrouting) parses the major conventions and converts between them.

### 👉 migrating

> [!IMPORTANT]
> **if you only use the header and request/response types, no migration is necessary**

1. `{ path: '/a/b' }` becomes `{ segments: ['/a', '/b'] }`, or `{ segments: ['/a/b'] }` if you'd rather keep the emitted tree shallow. a leading slash is optional, so `routeNodeKeys` output can go straight in.
2. `{ path: '/users', type: 'dynamic' }` becomes `{ segments: ['/users', DynamicParam] }`, and `type: 'wildcard'` becomes `WildcardParam`.
3. if you can't pass symbols across a serialisation boundary, `{ type: 'static', value }` / `{ type: 'dynamic' }` / `{ type: 'wildcard' }` are accepted too and produce identical output.
4. absolute URLs used to be split. now, pass the origin as its own segment: `{ segments: ['https://api.example.com', '/users'] }`.
5. `.` and `..` are no longer resolved. normalise before you pass segments in.
6. `DynamicParam`, `WildcardParam` and `Endpoint` are now value exports, since `segments` needs the symbol at runtime. `import type` still works for schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for resolving routes built from runtime values, including ambiguous responses when static and dynamic paths overlap.
- Improved typed fetch behavior for nested, wildcard, dynamic, and method-independent routes.
- Added public route and matching types for stronger route contracts.
- Routes without declared response types now resolve safely as `unknown`.

## Documentation
- Expanded guidance for route serialization, runtime values, handler typing, and shared HTTP methods.

## Tests
- Added coverage for route normalization, ambiguous matches, wildcard requests, and endpoint type resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->