### PR TITLE
feat: add loose typed header variants and clamp optional header values

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,22 @@ const contentType = response.headers.get('content-type') // string | null
 const customHeader = response.headers.get('x-custom') // Typed based on schema
 ```
 
+#### `LooseTypedHeaders<HeaderMap>` / `LooseTypedRequest<Body, HeaderMap>`
+
+Variants that type header *names* but leave every value as `string`. Use them when the header map is
+not known where the type is declared, such as when it comes from a generic parameter of your own
+type:
+
+```ts
+interface MyRequest<HeaderMap extends Record<string, string>> {
+  headers: LooseTypedHeaders<HeaderMap>
+}
+```
+
+`TypedHeaders` resolves each value with a conditional lookup into the map, which TypeScript cannot
+reduce while the map is still generic, so a plain `Headers` is neither assignable to nor from
+`TypedHeaders<HeaderMap>` in that position.
+
 ### Utilities
 
 #### `serializeRoutes(name, routes, options?)`

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,19 +1,47 @@
 import type { RequestHeaderMap, ResponseHeaderMap } from './http'
 
+type TypedHeaderName<TypedHeaderValues> = Extract<keyof TypedHeaderValues, string> | string & {}
+
+type TypedHeaderValue<TypedHeaderValues, Name extends string> = Lowercase<Name> extends keyof TypedHeaderValues ? Extract<TypedHeaderValues[Lowercase<Name>], string> : string
+
 export interface TypedHeaders<TypedHeaderValues extends Record<string, string> | unknown> extends Omit<Headers, 'append' | 'delete' | 'get' | 'getSetCookie' | 'has' | 'set' | 'forEach'> {
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/append) */
-  append: <Name extends Extract<keyof TypedHeaderValues, string> | string & {}> (name: Name, value: Lowercase<Name> extends keyof TypedHeaderValues ? TypedHeaderValues[Lowercase<Name>] : string) => void
+  append: <Name extends TypedHeaderName<TypedHeaderValues>> (name: Name, value: TypedHeaderValue<TypedHeaderValues, Name>) => void
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/delete) */
-  delete: <Name extends Extract<keyof TypedHeaderValues, string> | string & {}> (name: Name) => void
+  delete: <Name extends TypedHeaderName<TypedHeaderValues>> (name: Name) => void
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/get) */
-  get: <Name extends Extract<keyof TypedHeaderValues, string> | string & {}> (name: Name) => (Lowercase<Name> extends keyof TypedHeaderValues ? TypedHeaderValues[Lowercase<Name>] : string) | null
+  get: <Name extends TypedHeaderName<TypedHeaderValues>> (name: Name) => TypedHeaderValue<TypedHeaderValues, Name> | null
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie) */
   getSetCookie: () => string[]
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/has) */
-  has: <Name extends Extract<keyof TypedHeaderValues, string> | string & {}> (name: Name) => boolean
+  has: <Name extends TypedHeaderName<TypedHeaderValues>> (name: Name) => boolean
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/set) */
-  set: <Name extends Extract<keyof TypedHeaderValues, string> | string & {}> (name: Name, value: Lowercase<Name> extends keyof TypedHeaderValues ? TypedHeaderValues[Lowercase<Name>] : string) => void
-  forEach: (callbackfn: (value: TypedHeaderValues[keyof TypedHeaderValues] | string & {}, key: Extract<keyof TypedHeaderValues, string> | string & {}, parent: TypedHeaders<TypedHeaderValues>) => void, thisArg?: any) => void
+  set: <Name extends TypedHeaderName<TypedHeaderValues>> (name: Name, value: TypedHeaderValue<TypedHeaderValues, Name>) => void
+  forEach: (callbackfn: (value: Extract<TypedHeaderValues[keyof TypedHeaderValues], string> | string & {}, key: TypedHeaderName<TypedHeaderValues>, parent: TypedHeaders<TypedHeaderValues>) => void, thisArg?: any) => void
+}
+
+/**
+ * A variant of {@link TypedHeaders} that types header *names* but leaves every value as `string`.
+ *
+ * Use this when the header map is not known at the point of declaration, for example when it comes
+ * from a generic parameter of your own type. `TypedHeaders` resolves each value with a conditional
+ * lookup into the map, which TypeScript cannot reduce while the map is unresolved, so a plain
+ * `Headers` is neither assignable to nor from `TypedHeaders<M>` for a generic `M`.
+ */
+export interface LooseTypedHeaders<TypedHeaderValues extends Record<string, string> | unknown> extends Omit<Headers, 'append' | 'delete' | 'get' | 'getSetCookie' | 'has' | 'set' | 'forEach'> {
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/append) */
+  append: (name: TypedHeaderName<TypedHeaderValues>, value: string) => void
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/delete) */
+  delete: (name: TypedHeaderName<TypedHeaderValues>) => void
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/get) */
+  get: (name: TypedHeaderName<TypedHeaderValues>) => string | null
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie) */
+  getSetCookie: () => string[]
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/has) */
+  has: (name: TypedHeaderName<TypedHeaderValues>) => boolean
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Headers/set) */
+  set: (name: TypedHeaderName<TypedHeaderValues>, value: string) => void
+  forEach: (callbackfn: (value: string, key: TypedHeaderName<TypedHeaderValues>, parent: LooseTypedHeaders<TypedHeaderValues>) => void, thisArg?: any) => void
 }
 
 // type TypedHeaderTuples<TypedHeaderValues extends Record<string, string>> = {
@@ -34,4 +62,14 @@ export interface TypedRequest<Body = unknown, Headers extends Record<string, str
   clone: () => TypedRequest<Body, Headers>
   json: () => Promise<Body>
   headers: TypedHeaders<Headers>
+}
+
+/**
+ * A variant of {@link TypedRequest} whose headers are {@link LooseTypedHeaders}, for use where the
+ * header map comes from a generic parameter rather than being known up front.
+ */
+export interface LooseTypedRequest<Body = unknown, Headers extends Record<string, string> | unknown = RequestHeaderMap> extends Omit<Request, 'clone' | 'headers' | 'json'> {
+  clone: () => LooseTypedRequest<Body, Headers>
+  json: () => Promise<Body>
+  headers: LooseTypedHeaders<Headers>
 }

--- a/src/http/url.ts
+++ b/src/http/url.ts
@@ -35,5 +35,5 @@ export interface TypedURLSearchParams<QueryMap extends Record<string, string> | 
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams/set)
    */
   set: <Name extends Extract<keyof QueryMap, string> | string & {}> (name: Name, value: Name extends keyof QueryMap ? QueryMap[Name] extends string ? QueryMap[Name] : string : string) => void
-  forEach: (callbackfn: (value: QueryMap[keyof QueryMap] | string & {}, key: Extract<keyof QueryMap, string> | string & {}, parent: URLSearchParams) => void, thisArg?: any) => void
+  forEach: (callbackfn: (value: Extract<QueryMap[keyof QueryMap], string> | string & {}, key: Extract<keyof QueryMap, string> | string & {}, parent: URLSearchParams) => void, thisArg?: any) => void
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { TypedHeaders, TypedRequest, TypedResponse } from './fetch'
+export type { LooseTypedHeaders, LooseTypedRequest, TypedHeaders, TypedRequest, TypedResponse } from './fetch'
 
 export type { HTTPMethod, MimeType, RequestHeaderMap, RequestHeaderName, RequestHeaders, ResponseHeaderMap, ResponseHeaderName, ResponseHeaders } from './http'
 

--- a/test/typed-fetch.test-d.ts
+++ b/test/typed-fetch.test-d.ts
@@ -1,4 +1,4 @@
-import type { TypedHeaders, TypedRequest, TypedResponse } from '../src/fetch'
+import type { LooseTypedHeaders, LooseTypedRequest, TypedHeaders, TypedRequest, TypedResponse } from '../src/fetch'
 import type { RequestHeaderMap, ResponseHeaderMap } from '../src/http'
 import { describe, expectTypeOf, it } from 'vitest'
 
@@ -330,5 +330,60 @@ describe('Integration with fetchdts inference types', () => {
 
     expectTypeOf(getResponse.headers.get('x-total-count')).toEqualTypeOf<string | null>()
     expectTypeOf(postResponse.headers.get('location')).toEqualTypeOf<string | null>()
+  })
+})
+
+describe('optional header map keys', () => {
+  it('should not surface `undefined` for optional keys', () => {
+    type OptionalHeaders = TypedHeaders<{ 'x-thing'?: string }>
+
+    const headers = {} as OptionalHeaders
+
+    expectTypeOf(headers.get('x-thing')).toEqualTypeOf<string | null>()
+    expectTypeOf<OptionalHeaders>().toExtend<Headers>()
+    expectTypeOf<TypedResponse<unknown, { 'x-thing'?: string }>>().toExtend<Response>()
+  })
+})
+
+describe('LooseTypedHeaders', () => {
+  it('should type names but leave values as `string`', () => {
+    const headers = {} as LooseTypedHeaders<{ 'x-thing': 'a' | 'b' }>
+
+    expectTypeOf(headers.get).parameter(0).toEqualTypeOf<'x-thing' | string & {}>()
+    expectTypeOf(headers.get('x-thing')).toEqualTypeOf<string | null>()
+    expectTypeOf(headers.has).parameter(0).toEqualTypeOf<'x-thing' | string & {}>()
+  })
+
+  it('should be usable with a deferred header map', () => {
+    function toLoose<M>(headers: Headers): LooseTypedHeaders<M> {
+      return headers
+    }
+    function toPlain<M>(headers: LooseTypedHeaders<M>): Headers {
+      return headers
+    }
+    function toLooseRequest<Body, M>(request: Request): LooseTypedRequest<Body, M> {
+      return request
+    }
+
+    expectTypeOf(toLoose).not.toBeNever()
+    expectTypeOf(toPlain).not.toBeNever()
+    expectTypeOf(toLooseRequest).not.toBeNever()
+  })
+
+  it('should stay assignable through a wrapper generic over the map', () => {
+    type MapOf<T extends { headers?: unknown }> = Record<keyof ResponseHeaderMap, string>
+      // eslint-disable-next-line ts/no-empty-object-type
+      & (NonNullable<T['headers']> extends Record<string, string> ? NonNullable<T['headers']> : {})
+
+    interface Wrapper<T extends { headers?: unknown }> {
+      headers: LooseTypedHeaders<MapOf<T>>
+    }
+
+    function takesBase(_wrapper: Wrapper<{ headers?: unknown }>) {}
+    function passesSpecific<T extends { headers?: unknown }>(wrapper: Wrapper<T>) {
+      takesBase(wrapper)
+    }
+
+    expectTypeOf(passesSpecific).not.toBeNever()
   })
 })

--- a/test/url.test-d.ts
+++ b/test/url.test-d.ts
@@ -209,3 +209,14 @@ describe('TypedURLSearchParams', () => {
     expectTypeOf(params.get('unknown')).toEqualTypeOf<string | null>()
   })
 })
+
+describe('optional query map keys', () => {
+  it('should not surface `undefined` for optional keys', () => {
+    type OptionalParams = TypedURLSearchParams<{ a?: string }>
+
+    const params = {} as OptionalParams
+
+    expectTypeOf(params.get('a')).toEqualTypeOf<string | null>()
+    expectTypeOf<OptionalParams>().toExtend<URLSearchParams>()
+  })
+})


### PR DESCRIPTION
`TypedHeaders` can't be used when the header map comes from a generic.

this clamps value lookups to `Extract<..., string>` so optional keys behave, fixes the same issue in `TypedURLSearchParams['forEach']`, and adds `LooseTypedHeaders`/`LooseTypedRequest`, which type header names but leave values as `string`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible typed header and request types for use with header maps defined at runtime or through generics.
  * Exported the new types for public use.
* **Improvements**
  * Improved type safety for optional header and query parameter values, preventing unwanted `undefined` results.
  * Refined typed header and URL parameter value handling.
* **Documentation**
  * Added guidance on when to use flexible typed headers and requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->