### PR TITLE
fix: guard route serialisation against inherited keys and invalid input

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/node": "26.2.0",
     "@vitest/coverage-v8": "4.1.11",
     "eslint": "10.9.0",
+    "fast-check": "4.9.0",
     "installed-check": "11.0.0",
     "knip": "6.32.2",
     "lint-staged": "17.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint:
         specifier: 10.9.0
         version: 10.9.0(jiti@2.7.0)(supports-color@7.2.0)
+      fast-check:
+        specifier: 4.9.0
+        version: 4.9.0
       installed-check:
         specifier: 11.0.0
         version: 11.0.0
@@ -1496,6 +1499,10 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2179,6 +2186,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -3927,6 +3937,10 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -4793,6 +4807,8 @@ snapshots:
   proc-log@7.0.0: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.2: {}
 
   quansync@0.2.11: {}
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -39,9 +39,74 @@ export interface Route {
   [key: string]: unknown
 }
 
+/**
+ * Route keys, method names and metadata fields all come from user input, so every lookup table
+ * built from them has a null prototype; otherwise a route segment or method named `toString` or
+ * `constructor` would resolve to an inherited value.
+ */
+function dict<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>
+}
+
+const identifier = /^[$a-z_][\w$]*$/i
+
+/** reserved words, and the words reserved in strict mode, as the emitted schema is a module */
+const reserved = new Set([
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'instanceof',
+  'interface',
+  'let',
+  'new',
+  'null',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'return',
+  'static',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+])
+
 export function serializeRoutes(name: string, routes: Route[], options?: OutputOptions): string {
+  if (!identifier.test(name) || reserved.has(name)) {
+    throw new TypeError(`Cannot serialise routes as \`${name}\`, which is not a valid interface name.`)
+  }
+
   const imports = new Set<string>()
-  const tree: RouteTree = {}
+  const tree: RouteTree = dict()
 
   // build route tree
   for (const route of routes) {
@@ -51,14 +116,16 @@ export function serializeRoutes(name: string, routes: Route[], options?: OutputO
       if (typeof key === 'symbol') {
         imports.add(key === DynamicParam ? 'DynamicParam' : 'WildcardParam')
       }
-      node[key] = node[key] || {}
+      if (!Object.hasOwn(node, key)) {
+        node[key] = dict()
+      }
       node = node[key] as RouteTree
     }
 
     // an endpoint with no methods would be offered as a valid path but resolve to `never`, so a
     // route with no method metadata contributes its segments and nothing else
     const methods = Object.entries(route.metadata || {})
-      .filter((entry): entry is [string, Record<string, string>] => entry[1] !== undefined)
+      .filter((entry): entry is [string, Record<string, string>] => typeof entry[1] === 'object' && entry[1] !== null)
     if (methods.length === 0) {
       continue
     }
@@ -70,14 +137,14 @@ export function serializeRoutes(name: string, routes: Route[], options?: OutputO
 
     // distinct patterns can share a node, such as two parameters distinguished only by a constraint
     // the schema cannot express, so types are collected per field rather than overwritten
-    const endpoints = (node[Endpoint] = (node[Endpoint] as RouteTree) || {}) as Record<string, Record<string, string[]>>
+    const endpoints = (node[Endpoint] = (node[Endpoint] as RouteTree) || dict()) as Record<string, Record<string, string[]>>
     for (const [method, metadata] of methods) {
-      const existing = endpoints[method] = endpoints[method] || {}
+      const existing = endpoints[method] = Object.hasOwn(endpoints, method) ? endpoints[method]! : dict<string[]>()
       for (const [field, type] of Object.entries(metadata)) {
-        if (type === undefined) {
+        if (typeof type !== 'string') {
           continue
         }
-        const types = existing[field] = existing[field] || []
+        const types = existing[field] = Object.hasOwn(existing, field) ? existing[field]! : []
         if (!types.includes(type)) {
           types.push(type)
         }
@@ -94,11 +161,11 @@ export function serializeRoutes(name: string, routes: Route[], options?: OutputO
 
 const symbols = [DynamicParam, WildcardParam, Endpoint] as const
 
-const keys: Record<symbol | string, string> = {
+const keys: Record<symbol | string, string> = Object.assign(dict<string>(), {
   [DynamicParam]: '[DynamicParam]',
   [WildcardParam]: '[WildcardParam]',
   [Endpoint]: '[Endpoint]',
-}
+})
 
 function stringifyRouteTree(tree: RouteTree, indent = 2, metadata = false): string {
   let properties = ''
@@ -164,14 +231,18 @@ function segmentKey(segment: RouteSegment): string | symbol {
   if (typeof segment === 'symbol') {
     return segment
   }
-  switch (segment.type) {
+  switch (segment?.type) {
     case 'dynamic': return DynamicParam
     case 'wildcard': return WildcardParam
     case 'static': return staticKey(segment.value)
+    default: throw new TypeError(`Unknown route segment: ${JSON.stringify(segment)}.`)
   }
 }
 
 function staticKey(value: string): string {
+  if (typeof value !== 'string') {
+    throw new TypeError(`Static route segments must be strings, received ${JSON.stringify(value)}.`)
+  }
   // origins are matched as a single leading segment, so they keep their scheme instead of gaining a slash
   if (value.includes('://') || value.startsWith('/')) {
     return value

--- a/test/serialize.fuzz.test.ts
+++ b/test/serialize.fuzz.test.ts
@@ -1,0 +1,211 @@
+/* eslint-disable no-template-curly-in-string */
+import type { Route, RouteSegment } from '../src'
+import fc from 'fast-check'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+import { DynamicParam, serializeRoutes, WildcardParam } from '../src'
+
+const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD', 'CONNECT', 'TRACE', 'ALL'] as const
+const fields = ['queryType', 'headersType', 'bodyType', 'responseType', 'ambiguousResponseType', 'responseHeadersType'] as const
+
+/** type sources are opaque to the serializer, so they are drawn from a pool of valid ones */
+const typeSources = ['string', 'number', 'unknown', 'never', 'User', 'Post[]', 'A | B', '{ id: number }', 'Record<string, string>', '`/${string}`']
+
+const hostileStrings = [
+  '__proto__',
+  'constructor',
+  'prototype',
+  'toString',
+  'valueOf',
+  'hasOwnProperty',
+  '[Endpoint]',
+  '[DynamicParam]',
+  'Type',
+  'contentType',
+  '',
+  '/',
+  '"',
+  '\\',
+  '\n',
+  '${x}',
+  '*/ evil /*',
+  'https://api.example.com',
+  '//',
+  '://',
+]
+
+const staticValue = fc.oneof(
+  { arbitrary: fc.constantFrom(...hostileStrings), weight: 3 },
+  { arbitrary: fc.string(), weight: 2 },
+  { arbitrary: fc.string({ unit: 'binary' }), weight: 1 },
+)
+
+const segment: fc.Arbitrary<RouteSegment> = fc.oneof(
+  { arbitrary: staticValue, weight: 4 },
+  { arbitrary: staticValue.map(value => ({ type: 'static', value }) as const), weight: 2 },
+  { arbitrary: fc.constantFrom(DynamicParam, WildcardParam), weight: 2 },
+  { arbitrary: fc.constantFrom({ type: 'dynamic' } as const, { type: 'wildcard' } as const), weight: 2 },
+)
+
+/**
+ * A generator on the other side of a tool boundary is not bound by the declared types, so method
+ * names and metadata fields are fuzzed with inherited-property names as well as real ones.
+ */
+const inherited = fc.constantFrom('__proto__', 'constructor', 'toString', 'valueOf', 'hasOwnProperty')
+
+const metadata = fc.dictionary(
+  fc.oneof({ arbitrary: fc.constantFrom(...methods), weight: 4 }, { arbitrary: inherited, weight: 1 }) as fc.Arbitrary<typeof methods[number]>,
+  fc.oneof(
+    fc.constant(undefined),
+    fc.constant(null as never),
+    fc.dictionary(
+      fc.oneof({ arbitrary: fc.constantFrom(...fields), weight: 4 }, { arbitrary: inherited, weight: 1 }) as fc.Arbitrary<typeof fields[number]>,
+      fc.oneof({ arbitrary: fc.constantFrom(...typeSources), weight: 6 }, { arbitrary: fc.constant(undefined as never), weight: 1 }),
+    ),
+  ),
+  { maxKeys: 4 },
+)
+
+const route: fc.Arbitrary<Route> = fc.record({
+  segments: fc.array(segment, { minLength: 0, maxLength: 5 }),
+  metadata: fc.oneof(fc.constant(undefined), metadata),
+}, { requiredKeys: ['segments'] }) as fc.Arbitrary<Route>
+
+const routes = fc.array(route, { maxLength: 8 })
+
+const params = { numRuns: 500 }
+
+function syntaxErrors(code: string): string[] {
+  const source = ts.createSourceFile('schema.ts', code, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS)
+  const diagnostics = (source as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? []
+  return diagnostics.map(d => ts.flattenDiagnosticMessageText(d.messageText, ' '))
+}
+
+describe('serializeRoutes (property-based)', () => {
+  it('should emit syntactically valid TypeScript for any route set', () => {
+    fc.assert(fc.property(routes, fc.boolean(), (routes, exported) => {
+      const output = serializeRoutes('Schema', routes, { export: exported })
+      expect(syntaxErrors(output)).toEqual([])
+      expect(output.includes('export interface Schema')).toBe(exported)
+    }), params)
+  })
+
+  it('should either reject an interface name or emit valid TypeScript for it', () => {
+    const names = fc.oneof(
+      fc.string(),
+      fc.constantFrom('Schema', '$', '_x', 'interface', 'class', 'enum', 'do', 'await', 'static', 'yield', 'let', 'package', 'implements', 'true', 'null', 'void', 'function', 'string', 'any', 'type'),
+    )
+    fc.assert(fc.property(names, (name) => {
+      let output: string
+      try {
+        output = serializeRoutes(name, [])
+      }
+      catch (error) {
+        expect(error).toBeInstanceOf(TypeError)
+        return
+      }
+      expect(syntaxErrors(output)).toEqual([])
+    }), params)
+  })
+
+  it('should reject a segment it cannot represent', () => {
+    expect(() => serializeRoutes('Schema', [{ segments: [{ type: 'unknown' } as never] }])).toThrow(/Unknown route segment/)
+    expect(() => serializeRoutes('Schema', [{ segments: [{ type: 'static', value: 42 as never }] }])).toThrow(/must be strings/)
+  })
+
+  it('should be deterministic and insensitive to duplicated routes', () => {
+    fc.assert(fc.property(routes, (routes) => {
+      const output = serializeRoutes('Schema', routes)
+      expect(serializeRoutes('Schema', structuredCloneRoutes(routes))).toBe(output)
+      expect(serializeRoutes('Schema', [...routes, ...routes])).toBe(output)
+    }), params)
+  })
+
+  it('should import exactly the symbols it references', () => {
+    fc.assert(fc.property(routes, (routes) => {
+      const output = serializeRoutes('Schema', routes)
+      const [first] = output.split('\n')
+      const imported = new Set(first!.startsWith('import type')
+        ? first!.slice(first!.indexOf('{') + 1, first!.indexOf('}')).split(',').map(s => s.trim())
+        : [])
+      const body = output.slice(output.indexOf('interface Schema'))
+
+      for (const symbol of ['DynamicParam', 'WildcardParam', 'Endpoint']) {
+        expect(imported.has(symbol)).toBe(body.includes(`[${symbol}]:`))
+      }
+      expect(imported.has('HTTPMethod')).toBe(body.includes('HTTPMethod'))
+      expect([...imported]).toEqual([...imported].sort())
+    }), params)
+  })
+
+  it('should never leak host object properties into the output', () => {
+    fc.assert(fc.property(routes, (routes) => {
+      // a static segment may legitimately contain any of these, so only the value side is checked
+      for (const value of values(serializeRoutes('Schema', routes))) {
+        expect(value).not.toContain('native code')
+        expect(value).not.toContain('function')
+        expect(value).not.toContain('[object')
+      }
+    }), params)
+  })
+
+  it('should not mutate the routes it is given', () => {
+    fc.assert(fc.property(routes, (routes) => {
+      const before = JSON.stringify(routes, (_, value) => typeof value === 'symbol' ? String(value) : value)
+      serializeRoutes('Schema', routes)
+      expect(JSON.stringify(routes, (_, value) => typeof value === 'symbol' ? String(value) : value)).toBe(before)
+    }), params)
+  })
+
+  it('should represent every route segment in the output', () => {
+    fc.assert(fc.property(routes, (routes) => {
+      const output = serializeRoutes('Schema', routes)
+      for (const route of routes) {
+        for (const segment of route.segments) {
+          if (typeof segment === 'symbol' || (typeof segment !== 'string' && segment.type !== 'static')) {
+            continue
+          }
+          const value = typeof segment === 'string' ? segment : segment.value
+          const key = value.includes('://') || value.startsWith('/') ? value : `/${value}`
+          expect(output).toContain(JSON.stringify(key))
+        }
+      }
+    }), params)
+  })
+})
+
+function structuredCloneRoutes(routes: Route[]): Route[] {
+  return routes.map(route => ({ ...route, segments: [...route.segments] }))
+}
+
+/**
+ * The value of each emitted property, with the key discarded. Keys are `[Symbol]` or a JSON string,
+ * and a JSON string never contains a raw newline, so one property occupies exactly one line.
+ */
+function values(output: string): string[] {
+  const values: string[] = []
+  for (const line of output.split('\n')) {
+    const property = line.trimStart()
+    const key = property.startsWith('[')
+      ? property.slice(0, property.indexOf(']') + 1)
+      : property.startsWith('"') ? jsonStringPrefix(property) : undefined
+    if (key === undefined || !property.slice(key.length).startsWith(': ')) {
+      continue
+    }
+    values.push(property.slice(key.length + 2))
+  }
+  return values
+}
+
+function jsonStringPrefix(property: string): string {
+  for (let index = 1; index < property.length; index++) {
+    if (property[index] === '\\') {
+      index++
+      continue
+    }
+    if (property[index] === '"') {
+      return property.slice(0, index + 1)
+    }
+  }
+  return property
+}


### PR DESCRIPTION
found some issues with fast-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved route serialization safety when handling user-provided route, method, and metadata keys.
  - Added validation for interface names and route segments, with clear rejection of unsupported or invalid values.
  - Prevented inherited properties and non-string metadata values from appearing in generated output.
  - Improved deterministic output and duplicate handling without modifying input data.

- **Tests**
  - Added broad automated coverage for hostile inputs, invalid routes, symbol references, and generated TypeScript validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->